### PR TITLE
Fix #25 - Upgrade Parquet.Net to support parquet files with dots "." in column …

### DIFF
--- a/src/ParquetFileViewer/ParquetFileViewer.csproj
+++ b/src/ParquetFileViewer/ParquetFileViewer.csproj
@@ -47,7 +47,7 @@
       <HintPath>..\packages\IronSnappy.1.3.0\lib\netstandard2.0\IronSnappy.dll</HintPath>
     </Reference>
     <Reference Include="Parquet, Version=3.0.0.0, Culture=neutral, PublicKeyToken=d380b3dee6d01926, processorArchitecture=MSIL">
-      <HintPath>..\packages\Parquet.Net.3.8.1\lib\netstandard2.0\Parquet.dll</HintPath>
+      <HintPath>..\packages\Parquet.Net.3.8.3\lib\netstandard2.0\Parquet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/src/ParquetFileViewer/packages.config
+++ b/src/ParquetFileViewer/packages.config
@@ -3,7 +3,7 @@
   <package id="Costura.Fody" version="4.1.0" targetFramework="net461" />
   <package id="Fody" version="6.3.0" targetFramework="net461" developmentDependency="true" />
   <package id="IronSnappy" version="1.3.0" targetFramework="net461" />
-  <package id="Parquet.Net" version="3.8.1" targetFramework="net461" />
+  <package id="Parquet.Net" version="3.8.3" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />


### PR DESCRIPTION
Fix #25 