### PR TITLE
added feature to support single and multiple fields filtering

### DIFF
--- a/src/ParquetFileViewer/FieldSelectionDialog.Designer.cs
+++ b/src/ParquetFileViewer/FieldSelectionDialog.Designer.cs
@@ -32,21 +32,26 @@
             this.allFieldsRadioButton = new System.Windows.Forms.RadioButton();
             this.showSelectedFieldsRadioButton = new System.Windows.Forms.RadioButton();
             this.fieldsPanel = new System.Windows.Forms.Panel();
-            this.doneButton = new System.Windows.Forms.Button();
             this.allFieldsRememberRadioButton = new System.Windows.Forms.RadioButton();
+            this.doneButton = new System.Windows.Forms.Button();
+            this.filterColumnsTextbox = new System.Windows.Forms.TextBox();
+            this.clearfilterColumnsButton = new System.Windows.Forms.Button();
             this.mainTableLayoutPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // mainTableLayoutPanel
             // 
-            this.mainTableLayoutPanel.ColumnCount = 2;
+            this.mainTableLayoutPanel.ColumnCount = 3;
             this.mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.mainTableLayoutPanel.Controls.Add(this.allFieldsRadioButton, 0, 0);
             this.mainTableLayoutPanel.Controls.Add(this.showSelectedFieldsRadioButton, 0, 2);
-            this.mainTableLayoutPanel.Controls.Add(this.fieldsPanel, 1, 3);
-            this.mainTableLayoutPanel.Controls.Add(this.doneButton, 1, 4);
+            this.mainTableLayoutPanel.Controls.Add(this.fieldsPanel, 1, 4);
             this.mainTableLayoutPanel.Controls.Add(this.allFieldsRememberRadioButton, 0, 1);
+            this.mainTableLayoutPanel.Controls.Add(this.doneButton, 1, 5);
+            this.mainTableLayoutPanel.Controls.Add(this.filterColumnsTextbox, 1, 3);
+            this.mainTableLayoutPanel.Controls.Add(this.clearfilterColumnsButton, 2, 3);
             this.mainTableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.mainTableLayoutPanel.Location = new System.Drawing.Point(0, 0);
             this.mainTableLayoutPanel.Name = "mainTableLayoutPanel";
@@ -54,6 +59,7 @@
             this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 28F));
             this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.mainTableLayoutPanel.Size = new System.Drawing.Size(429, 346);
@@ -92,24 +98,13 @@
             // fieldsPanel
             // 
             this.fieldsPanel.AutoScroll = true;
+            this.mainTableLayoutPanel.SetColumnSpan(this.fieldsPanel, 2);
             this.fieldsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.fieldsPanel.Enabled = false;
-            this.fieldsPanel.Location = new System.Drawing.Point(23, 93);
+            this.fieldsPanel.Location = new System.Drawing.Point(23, 121);
             this.fieldsPanel.Name = "fieldsPanel";
-            this.fieldsPanel.Size = new System.Drawing.Size(403, 220);
+            this.fieldsPanel.Size = new System.Drawing.Size(403, 192);
             this.fieldsPanel.TabIndex = 2;
-            // 
-            // doneButton
-            // 
-            this.doneButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.doneButton.Location = new System.Drawing.Point(329, 319);
-            this.doneButton.Name = "doneButton";
-            this.doneButton.Size = new System.Drawing.Size(97, 24);
-            this.doneButton.TabIndex = 3;
-            this.doneButton.Text = "Done";
-            this.doneButton.UseVisualStyleBackColor = true;
-            this.doneButton.Click += new System.EventHandler(this.doneButton_Click);
             // 
             // allFieldsRememberRadioButton
             // 
@@ -124,6 +119,42 @@
             this.allFieldsRememberRadioButton.Text = "All Fields... (remember my choice)";
             this.allFieldsRememberRadioButton.UseVisualStyleBackColor = true;
             this.allFieldsRememberRadioButton.CheckedChanged += new System.EventHandler(this.AllFieldsRememberRadioButton_CheckedChanged);
+            // 
+            // doneButton
+            // 
+            this.doneButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.mainTableLayoutPanel.SetColumnSpan(this.doneButton, 2);
+            this.doneButton.Location = new System.Drawing.Point(329, 319);
+            this.doneButton.Name = "doneButton";
+            this.doneButton.Size = new System.Drawing.Size(97, 24);
+            this.doneButton.TabIndex = 3;
+            this.doneButton.Text = "Done";
+            this.doneButton.UseVisualStyleBackColor = true;
+            this.doneButton.Click += new System.EventHandler(this.doneButton_Click);
+            // 
+            // filterColumnsTextbox
+            // 
+            this.filterColumnsTextbox.Enabled = false;
+            this.filterColumnsTextbox.Location = new System.Drawing.Point(23, 93);
+            this.filterColumnsTextbox.Name = "filterColumnsTextbox";
+            this.filterColumnsTextbox.Size = new System.Drawing.Size(373, 20);
+            this.filterColumnsTextbox.TabIndex = 0;
+            this.filterColumnsTextbox.TextChanged += new System.EventHandler(this.filterColumnsTextbox_TextChanged);
+            // 
+            // clearfilterColumnsButton
+            // 
+            this.clearfilterColumnsButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.clearfilterColumnsButton.Enabled = false;
+            this.clearfilterColumnsButton.Location = new System.Drawing.Point(402, 93);
+            this.clearfilterColumnsButton.Name = "clearfilterColumnsButton";
+            this.clearfilterColumnsButton.Size = new System.Drawing.Size(24, 22);
+            this.clearfilterColumnsButton.TabIndex = 4;
+            this.clearfilterColumnsButton.Text = "X";
+            this.clearfilterColumnsButton.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.clearfilterColumnsButton.UseVisualStyleBackColor = true;
+            this.clearfilterColumnsButton.Click += new System.EventHandler(this.clearfilterColumnsButton_Click);
             // 
             // FieldsToLoadForm
             // 
@@ -150,5 +181,7 @@
         private System.Windows.Forms.Panel fieldsPanel;
         private System.Windows.Forms.Button doneButton;
         private System.Windows.Forms.RadioButton allFieldsRememberRadioButton;
+        private System.Windows.Forms.TextBox filterColumnsTextbox;
+        private System.Windows.Forms.Button clearfilterColumnsButton;
     }
 }

--- a/src/ParquetFileViewer/FieldSelectionDialog.cs
+++ b/src/ParquetFileViewer/FieldSelectionDialog.cs
@@ -13,9 +13,10 @@ namespace ParquetFileViewer
         private const int DynamicFieldCheckboxYIncrement = 30;
         public static readonly List<SchemaType> UnsupportedSchemaTypes = new List<SchemaType>() { SchemaType.List, SchemaType.Map, SchemaType.Struct };
 
-        public IEnumerable<string> PreSelectedFields { get; set; }
+        public List<string> PreSelectedFields { get; set; }
         public IEnumerable<Field> AvailableFields { get; set; }
         public List<string> NewSelectedFields { get; set; }
+        public List<string> PreserveSelectedFields { get; set; }
 
         public FieldsToLoadForm()
         {
@@ -29,19 +30,24 @@ namespace ParquetFileViewer
         {
             InitializeComponent();
             this.AvailableFields = availableFields;
-            this.PreSelectedFields = preSelectedFields ?? new List<string>();
+            this.PreSelectedFields = preSelectedFields.ToList() ?? new List<string>();
             this.NewSelectedFields = new List<string>();
         }
 
         private void FieldsToLoadForm_Load(object sender, EventArgs e)
         {
             this.CenterToParent();
+            this.RenderFieldsCheckboxes(this.AvailableFields, this.PreSelectedFields);
+        }
+
+        private void RenderFieldsCheckboxes(IEnumerable<Field> availableFields, IEnumerable<string> preSelectedFields)
+        {
             this.fieldsPanel.SuspendLayout(); //Suspending the layout while dynamically adding controls adds significant performance improvement
             this.fieldsPanel.Controls.Clear();
 
             try
             {
-                if (this.AvailableFields != null)
+                if (availableFields != null)
                 {
                     int locationX = 0;
                     int locationY = 5;
@@ -49,15 +55,15 @@ namespace ParquetFileViewer
                     HashSet<string> fieldNames = new HashSet<string>();
                     bool isClearingSelectAllCheckbox = false;
 
-                    foreach (Field field in this.AvailableFields)
+                    foreach (Field field in availableFields)
                     {
                         if (isFirst) //Add toggle all checkbox and some other setting changes
                         {
                             isFirst = false;
 
-                            if (this.PreSelectedFields != null)
+                            if (preSelectedFields != null)
                             {
-                                foreach (string preSelectedField in this.PreSelectedFields)
+                                foreach (string preSelectedField in preSelectedFields)
                                 {
                                     this.showSelectedFieldsRadioButton.Checked = true;
                                     break;
@@ -77,6 +83,10 @@ namespace ParquetFileViewer
                             selectAllCheckbox.CheckedChanged += (object checkboxSender, EventArgs checkboxEventArgs) =>
                             {
                                 var selectAllCheckBox = (CheckBox)checkboxSender;
+                                var showFilterControls = !(selectAllCheckBox.Enabled && selectAllCheckBox.Checked && string.IsNullOrWhiteSpace(this.filterColumnsTextbox.Text));
+                                this.filterColumnsTextbox.Enabled = showFilterControls;
+                                this.clearfilterColumnsButton.Enabled = showFilterControls;
+
                                 if (!isClearingSelectAllCheckbox)
                                 {
                                     foreach (Control control in this.fieldsPanel.Controls)
@@ -84,7 +94,10 @@ namespace ParquetFileViewer
                                         if (!control.Tag.Equals(SelectAllCheckboxName) && control is CheckBox checkbox)
                                         {
                                             if (checkbox.Enabled)
+                                            {
                                                 checkbox.Checked = selectAllCheckBox.Checked;
+                                                //this.PreSelectedFields.Remove((string)checkbox.Tag);
+                                            }
                                         }
                                     }
                                 }
@@ -102,7 +115,7 @@ namespace ParquetFileViewer
                                 Name = string.Concat("checkbox_", field.Name),
                                 Text = string.Concat(field.Name, isUnsupportedFieldType ? "(Unsupported)" : string.Empty),
                                 Tag = field.Name,
-                                Checked = this.PreSelectedFields.Contains(field.Name),
+                                Checked = preSelectedFields.Contains(field.Name),
                                 Location = new Point(locationX, locationY),
                                 AutoSize = true,
                                 Enabled = !isUnsupportedFieldType
@@ -110,6 +123,17 @@ namespace ParquetFileViewer
                             fieldCheckbox.CheckedChanged += (object checkboxSender, EventArgs checkboxEventArgs) =>
                             {
                                 var fieldCheckBox = (CheckBox)checkboxSender;
+
+                                if (fieldCheckBox.Checked)
+                                {
+                                    this.PreSelectedFields.Add((string)fieldCheckBox.Tag);
+                                }
+                                else
+                                {
+                                    this.PreSelectedFields.Remove((string)fieldCheckBox.Tag);
+                                }
+
+
                                 if (!fieldCheckBox.Checked)
                                 {
                                     foreach (Control control in this.fieldsPanel.Controls)
@@ -120,6 +144,7 @@ namespace ParquetFileViewer
                                             {
                                                 isClearingSelectAllCheckbox = true;
                                                 checkbox.Checked = false;
+                                                this.PreSelectedFields.Remove((string)fieldCheckBox.Tag);
                                                 isClearingSelectAllCheckbox = false;
                                                 break;
                                             }
@@ -150,6 +175,8 @@ namespace ParquetFileViewer
             if (((RadioButton)sender).Checked)
             {
                 this.fieldsPanel.Enabled = false;
+                this.filterColumnsTextbox.Enabled = false;
+                this.clearfilterColumnsButton.Enabled = false;
                 this.allFieldsRememberRadioButton.Checked = false;
                 this.showSelectedFieldsRadioButton.Checked = false;
             }
@@ -160,6 +187,8 @@ namespace ParquetFileViewer
             if (((RadioButton)sender).Checked)
             {
                 this.fieldsPanel.Enabled = false;
+                this.filterColumnsTextbox.Enabled = false;
+                this.clearfilterColumnsButton.Enabled = false;
                 this.allFieldsRadioButton.Checked = false;
                 this.showSelectedFieldsRadioButton.Checked = false;
             }
@@ -170,6 +199,8 @@ namespace ParquetFileViewer
             if (((RadioButton)sender).Checked)
             {
                 this.fieldsPanel.Enabled = true;
+                this.filterColumnsTextbox.Enabled = true;
+                this.clearfilterColumnsButton.Enabled = true;
                 this.allFieldsRadioButton.Checked = false;
                 this.allFieldsRememberRadioButton.Checked = false;
             }
@@ -224,6 +255,39 @@ namespace ParquetFileViewer
         private void ShowError(Exception ex, string customMessage = null, bool showStackTrace = true)
         {
             MessageBox.Show(string.Concat(customMessage ?? "Something went wrong:", Environment.NewLine, showStackTrace ? ex.ToString() : ex.Message), ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+
+
+        private void filterColumnsTextbox_TextChanged(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(this.filterColumnsTextbox.Text))
+            {
+                IEnumerable<Field> filteredFields;
+                var filteredColumnsNames = this.filterColumnsTextbox.Text.Split(',').ToList();
+
+                if (filteredColumnsNames.Count == 1)
+                {
+                    var filter = filteredColumnsNames[0];
+                    filteredFields = this.AvailableFields.Where(w => w.Name.Contains(filter));
+                }
+                else
+                {
+                    char[] charsToTrim = { '"', ' ', '\'' };
+                    filteredColumnsNames = filteredColumnsNames.Select(s => s.Trim(charsToTrim)).ToList();
+                    filteredFields = this.AvailableFields.Where(w => filteredColumnsNames.Contains(w.Name));
+                }
+
+                this.RenderFieldsCheckboxes(filteredFields, this.PreSelectedFields);
+            }
+            else
+            {
+                this.RenderFieldsCheckboxes(this.AvailableFields, this.PreSelectedFields);
+            }
+        }
+
+        private void clearfilterColumnsButton_Click(object sender, EventArgs e)
+        {
+            this.filterColumnsTextbox.Text = string.Empty;
         }
     }
 }


### PR DESCRIPTION
- added feature to support single and multiple fields filtering based on string split

Hello, first of all let me thanks you for the app you build, it's great for my current project. 
After using it, i noticed if it could be somehow improved. 
I was struggling with the filter because i need to filter for ex. 20 datetime columns out of 400 or 500 columns parquet files. 
So i decided to try to improve the selected fields feature. I believe i did a good job. 
I placed an additional textbox that allows filtering for a single column or a multiple columns using a string.split with commas separated string. This is useful to me for fast select of all columns which can come from a metadata file or something alike. 
If you find it useful, maybe you can include it with in your repo source files. 

If you have any questions please let me know. 
Just a note, this is my first fork / pull request in Github so please bear with me if i made something wrong. 

Agains thanks for the tool.
Hope to hear from you.
Cheers


