### PR TITLE
V2.4.2 release

### DIFF
--- a/src/ParquetFileViewer/MainForm.Designer.cs
+++ b/src/ParquetFileViewer/MainForm.Designer.cs
@@ -91,7 +91,7 @@ namespace ParquetFileViewer
             // mainTableLayoutPanel
             // 
             this.mainTableLayoutPanel.ColumnCount = 10;
-            this.mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 61F));
+            this.mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
             this.mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 35F));
             this.mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 93F));
             this.mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
@@ -200,10 +200,10 @@ namespace ParquetFileViewer
             this.searchFilterLabel.Location = new System.Drawing.Point(4, 11);
             this.searchFilterLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.searchFilterLabel.Name = "searchFilterLabel";
-            this.searchFilterLabel.Size = new System.Drawing.Size(88, 13);
+            this.searchFilterLabel.Size = new System.Drawing.Size(97, 13);
             this.searchFilterLabel.TabIndex = 7;
             this.searchFilterLabel.TabStop = true;
-            this.searchFilterLabel.Text = "Filter Query:";
+            this.searchFilterLabel.Text = "Filter Query (?):";
             this.searchFilterLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.searchFilterLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.searchFilterLabel_Click);
             // 
@@ -211,10 +211,10 @@ namespace ParquetFileViewer
             // 
             this.searchFilterTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.mainTableLayoutPanel.SetColumnSpan(this.searchFilterTextBox, 2);
-            this.searchFilterTextBox.Location = new System.Drawing.Point(100, 6);
+            this.searchFilterTextBox.Location = new System.Drawing.Point(109, 6);
             this.searchFilterTextBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.searchFilterTextBox.Name = "searchFilterTextBox";
-            this.searchFilterTextBox.Size = new System.Drawing.Size(374, 23);
+            this.searchFilterTextBox.Size = new System.Drawing.Size(365, 23);
             this.searchFilterTextBox.TabIndex = 1;
             this.searchFilterTextBox.Text = "WHERE ";
             this.searchFilterTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.searchFilterTextBox_KeyPress);
@@ -366,12 +366,12 @@ namespace ParquetFileViewer
             // 
             // changeFieldsMenuStripButton
             // 
+            this.changeFieldsMenuStripButton.Image = ((System.Drawing.Image)(resources.GetObject("changeFieldsMenuStripButton.Image")));
             this.changeFieldsMenuStripButton.Name = "changeFieldsMenuStripButton";
             this.changeFieldsMenuStripButton.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
             this.changeFieldsMenuStripButton.Size = new System.Drawing.Size(217, 22);
             this.changeFieldsMenuStripButton.Text = "Add/Remove &Fields";
             this.changeFieldsMenuStripButton.Click += new System.EventHandler(this.redoToolStripMenuItem_Click);
-            this.changeFieldsMenuStripButton.Image = global::ParquetFileViewer.Properties.Resources.list_icon_32x32.ToBitmap();
             // 
             // changeDateFormatToolStripMenuItem
             // 
@@ -382,10 +382,10 @@ namespace ParquetFileViewer
             this.iSO8601DateOnlyToolStripMenuItem,
             this.iSO8601Alt1ToolStripMenuItem,
             this.iSO8601Alt2ToolStripMenuItem});
+            this.changeDateFormatToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("changeDateFormatToolStripMenuItem.Image")));
             this.changeDateFormatToolStripMenuItem.Name = "changeDateFormatToolStripMenuItem";
             this.changeDateFormatToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
             this.changeDateFormatToolStripMenuItem.Text = "Date Format";
-            this.changeDateFormatToolStripMenuItem.Image = global::ParquetFileViewer.Properties.Resources.calendar_icon.ToBitmap();
             // 
             // defaultToolStripMenuItem
             // 
@@ -504,11 +504,11 @@ namespace ParquetFileViewer
             // getSQLCreateTableScriptToolStripMenuItem
             // 
             this.getSQLCreateTableScriptToolStripMenuItem.Enabled = false;
+            this.getSQLCreateTableScriptToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("getSQLCreateTableScriptToolStripMenuItem.Image")));
             this.getSQLCreateTableScriptToolStripMenuItem.Name = "getSQLCreateTableScriptToolStripMenuItem";
             this.getSQLCreateTableScriptToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.getSQLCreateTableScriptToolStripMenuItem.Text = "Get SQL Create Table Script";
             this.getSQLCreateTableScriptToolStripMenuItem.Click += new System.EventHandler(this.GetSQLCreateTableScriptToolStripMenuItem_Click);
-            this.getSQLCreateTableScriptToolStripMenuItem.Image = global::ParquetFileViewer.Properties.Resources.sql_server_icon.ToBitmap();
             // 
             // metadataViewerToolStripMenuItem
             // 
@@ -518,7 +518,6 @@ namespace ParquetFileViewer
             this.metadataViewerToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.metadataViewerToolStripMenuItem.Text = "Metadata Viewer";
             this.metadataViewerToolStripMenuItem.Click += new System.EventHandler(this.MetadataViewerToolStripMenuItem_Click);
-            this.metadataViewerToolStripMenuItem.Image = global::ParquetFileViewer.Properties.Resources.text_file_icon.ToBitmap();
             // 
             // helpToolStripMenuItem
             // 
@@ -532,14 +531,14 @@ namespace ParquetFileViewer
             // userGuideToolStripMenuItem
             // 
             this.userGuideToolStripMenuItem.Name = "userGuideToolStripMenuItem";
-            this.userGuideToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
+            this.userGuideToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.userGuideToolStripMenuItem.Text = "User Guide";
             this.userGuideToolStripMenuItem.Click += new System.EventHandler(this.userGuideToolStripMenuItem_Click);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.aboutToolStripMenuItem.Text = "&About...";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 

--- a/src/ParquetFileViewer/MainForm.resx
+++ b/src/ParquetFileViewer/MainForm.resx
@@ -122,6 +122,52 @@
         IwSUkyd6+HrShtGS0DvTU9G0aWDUM51KRfDOuKxowb9FktYATrQ4xbl82G8AAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="changeFieldsMenuStripButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAMASURBVFhH3dfZi41hHMDxIbvIvu9blkFKkRTKvoRcWEr2
+        wYQz1mTNnhBCybXClaIUyoXlxoxhUG4wlinbBX+C7/d4Xk6n15lXc47kV5+M8bzv87zP8vs9iv6pSFW8
+        U3ssxFIsCfx5+Ab+vaz8h7zH2mevowHY4UFMxbTw5yLsCUYjPJXHWPu0OhrAitDRatQvq6zxd2NxFzcx
+        EK3RHwMSsF071EPoLSayBrADDzASm/EC5+Dy6Do+4kMCtruBTgi9xUTGAEowGefxEvfhEmxFUzTCFKz7
+        Ay5lY4TeYiJjAE79PEzAWQxHPxyHAwhP5DnWVL2KBuAmO4MDwX6cxCrkXse6hi8PnbjOPdA96AqnPrQs
+        UNgBRsGpP5ThFFyavzIDbsL5aIaWaAGP0rHwu9C6AOHLsRITo47C79rA5OQAGmIclsMjWxvbuaFrX0Ib
+        IG4AbeFSeAo6wHP9BZ8TsN0tdEb6nb8NG8DdHjcDh9E8VfHWv3fEEBQnYDuTUO37xwZYDDubjlmYCafR
+        jZg7mdQ1fDmcbhORFTFiJixOUQVTjwo/AKY5XXwmwaWIdEO6TUGi9Fc5XgCn26VYBu8Cm7Az/DwUResf
+        vQlP5ikyaoGnwAo4B+mNg0GwAj6EFdLc0BO9ErBdK6Tf/9vIKsee+XuwCJmUHuMy+sLafhU1eJ+A7a4h
+        cTn2GM7ARfjFT7AFG9EEnoTZsDwnNRc+G3qLiaxy7DXMO8EVWBtMIkdRuFRc8uRlNAB3/AXsg0vh9cxy
+        7JfUR3iiAOHLQyd+cR/0DtxIuaewrlH6/OeFxNQZffnewMzoqTBHpLPhuvLq8GSeImMPWI7XYzCiS8kw
+        WIw8iu6Ngg7AY3gCXkr8Wr+6DFU4Aquh90RPgrNSG9uNQAOE3mIiYwAmIk+C/w8w811CJbbDATmA2/iG
+        rwnY7g66IPQWE1lL4AViNz7B67lf4F7wGLpJTUjWi6RMaLlP0Jqqn7XAGTDpmIx2YQy815/GXynH5m8H
+        oBQsRNswHuk2/1EUFX0HJ/684q+HdAgAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="changeDateFormatToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACsSURBVFhH7Y7LCgIxEAQDevfm/3+lJ0VH2Q4x8zCJ6YWF
+        FNRhpztsp0XARXxujoL3589XJ+WPR0b89f4q7j7gJL6LpaC+twq8+xd1qSxaWYsgyjJ30SvV91ZBlGWi
+        kpW1CKIsY5WYKqwSU4VVYqpwg8msAV0DbpUlo1nXANwYmcINJnOsAbgxMkVUZmQKN5jMsQbgxsgUUZmR
+        KdxgMmvAzwF7+BBNrDLDxUZKL5B+ek8G0AbiAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="getSQLCreateTableScriptToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK6SURBVFhH7VdNaxNRFI1DrClU2pXgoj/AplL6ke+kSQtm
+        kSCkiyAWxE1tLQRiWttgpGiXXQaqJYuCSKS7CFKMpWgX/QARTTOSxo8sBRfiwh8wuZ338l76ZvJmkiZF
+        XeTAgZl775xz5k5mIIb/HuXXhgvwygDwRuaWinId9cmoJnoe9sD6wbrXFDdB13KX1xg1QmAtAKhORpSQ
+        ti//rppkDfBr9y4c5d6BmM9BXixgFnJ78OPgEe7TWWlTeE8kmgc1zYufQRTFhonmaRgipYtYJublbgAJ
+        8AwaZaMBNIEEfu4nuOL1+GcncDYboJSyJvj6MQOH4hHX8FD8AqUPz6G8JVSvQSRSzYEVaojoue/1A5Qe
+        V2tEShcNbUCXpeWKKUvSI1LNQWGix3aAdoB2ADmAVIxvTE9HNnw+PzaF7Uu4h4U04PcH9QPWGGmRbEAq
+        3itYrW5wu8fA4xkH6dPNt0SqBmgGcWDAoh2Ca6YinmMfwfcEmM2DWNxm89SIp1Kp89SccnjYwQ/BM1ST
+        jMohKgHK3x54WXHSxkin01fZHqLT6eWbI/AM1URzrFEkEp2h4i7XiXg8vnSd1inR4yJtPniGapZ3+yfU
+        wixjsfsTSGtoyK6oo3NsoodyceEiz1RNNMuKU87ORq+EwzeeoN8CW7fZ6tw5D7DJN6eUdswpMorhdo/D
+        6uraC9bYanWd3rhV2O0nd09Kfw8jIw6w20flTTy9NTl5Gwfo6xvUD9Ix13EmSdHr5fNdw1roeGpq5g7d
+        hMXi1PYIPwu3HMDjGYNQSKlDzSnRdkhLic7FzpYCuFw++Q5d++RUAXUIh4PzETLOG5sOgESDwZDu9bUh
+        RpXz8y/nsuTwVEBiTqevofBoS2wIUq6gO9GNC8KiACvZFY+wIEAik4DepV5NcfRVSyaTdf+YsmDMz1Uq
+        /xwGwzFIl5WH4imekwAAAABJRU5ErkJggg==
+</value>
+  </data>
   <metadata name="mainStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>308, 17</value>
   </metadata>

--- a/src/ParquetFileViewer/ParquetFileViewer.csproj
+++ b/src/ParquetFileViewer/ParquetFileViewer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Parquet.Net" Version="4.0.2" />
+    <PackageReference Include="Parquet.Net" Version="4.1.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/ParquetFileViewer/ParquetFileViewer.csproj
+++ b/src/ParquetFileViewer/ParquetFileViewer.csproj
@@ -9,6 +9,7 @@
 	<SelfContained>false</SelfContained>
 	<PublishSingleFile>true</PublishSingleFile>
 	<PublishReadyToRun>false</PublishReadyToRun>
+	<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\parquet_icon.ico</ApplicationIcon>

--- a/src/ParquetFileViewer/Properties/AssemblyInfo.cs
+++ b/src/ParquetFileViewer/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.4.1.2")]
+[assembly: AssemblyVersion("2.4.2.0")]

--- a/src/ParquetFileViewer/Properties/AssemblyInfo.cs
+++ b/src/ParquetFileViewer/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Parquet Viewer")]
-[assembly: AssemblyDescription("Simple windows desktop application for viewing Apache Parquet files\r\nhttps://github.com/mukunku/ParquetViewer\r\n\r\nSpecial thanks to: https://github.com/elastacloud/parquet-dotnet")]
+[assembly: AssemblyDescription("Simple windows desktop application for viewing Apache Parquet files\r\nhttps://github.com/mukunku/ParquetViewer\r\n\r\nSpecial thanks to: https://github.com/aloneguid/parquet-dotnet")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Author: Mukunku")]
 [assembly: AssemblyProduct("Parquet Viewer")]


### PR DESCRIPTION
Bump parquet.net package version to 4.1.0 which adds zstd support.

I had to enable `IncludeNativeLibrariesForSelfExtract` otherwise .net 6 wouldn't package this as a single executable; leaving a `nironcompress.dll` in the publish folder. Setting that option to true worked but the executable grew in size by around ~500kb. But I think it's worth it for ZSTD support.