### PR TITLE
v2.5 Release - upgrade to .net 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Pre-compiled releases can be found here: https://github.com/mukunku/ParquetViewe
 Visit the Wiki for details on how to use the utility: https://github.com/mukunku/ParquetViewer/wiki
 
 # Technical Details
-The latest version of this project was written in C# using Visual Studio 2022 v17.4 and .NET 6
+The latest version of this project was written in C# using Visual Studio 2022 v17.4.3 and .NET 7
 
 # Acknowledgements
 This utility would not be possible without: https://github.com/aloneguid/parquet-dotnet

--- a/src/ParquetFileViewer/App.config
+++ b/src/ParquetFileViewer/App.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/ParquetFileViewer/AppSettings.cs
+++ b/src/ParquetFileViewer/AppSettings.cs
@@ -10,6 +10,7 @@ namespace ParquetFileViewer
         private const string UseISODateFormatKey = "UseISODateFormat";
         private const string AlwaysSelectAllFieldsKey = "AlwaysSelectAllFields";
         private const string DefaultRowCountKey = "DefaultRowCount";
+        private const string RememberLastRowCountKey = "RememberLastRowCount";
         private const string ParquetReadingEngineKey = "ParquetReadingEngine";
         private const string AutoSizeColumnsModeKey = "AutoSizeColumnsMode";
         private const string DateTimeDisplayFormatKey = "DateTimeDisplayFormat";
@@ -102,8 +103,7 @@ namespace ParquetFileViewer
                 {
                     using (RegistryKey registryKey = Registry.CurrentUser.CreateSubKey(RegistrySubKey))
                     {
-                        bool value = false;
-                        bool.TryParse(registryKey.GetValue(AlwaysSelectAllFieldsKey)?.ToString(), out value);
+                        bool.TryParse(registryKey.GetValue(AlwaysSelectAllFieldsKey)?.ToString(), out var value);
                         return value;
                     }
                 }
@@ -125,22 +125,24 @@ namespace ParquetFileViewer
             }
         }
 
-        public static int DefaultRowCount
+        public static int? LastRowCount
         {
             get
             {
                 try
                 {
+                    if (!RememberLastRowCount)
+                        return null;
+
                     using (RegistryKey registryKey = Registry.CurrentUser.CreateSubKey(RegistrySubKey))
                     {
-                        int value = 1000;
-                        int.TryParse(registryKey.GetValue(DefaultRowCountKey)?.ToInt32(), out value);
-                        return value;
+                        int.TryParse(registryKey.GetValue(DefaultRowCountKey)?.ToString(), out var value);
+                        return value <= 0 ? null : value;
                     }
                 }
                 catch
                 {
-                    return 1000;
+                    return null;
                 }
             }
             set
@@ -149,7 +151,37 @@ namespace ParquetFileViewer
                 {
                     using (RegistryKey registryKey = Registry.CurrentUser.CreateSubKey(RegistrySubKey))
                     {
-                        registryKey.SetValue(DefaultRowCountKey, value.ToInt32());
+                        registryKey.SetValue(DefaultRowCountKey, value.ToString());
+                    }
+                }
+                catch { }
+            }
+        }
+
+        public static bool RememberLastRowCount
+        {
+            get
+            {
+                try
+                {
+                    using (RegistryKey registryKey = Registry.CurrentUser.CreateSubKey(RegistrySubKey))
+                    {
+                        bool.TryParse(registryKey.GetValue(RememberLastRowCountKey)?.ToString(), out var value);
+                        return value;
+                    }
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+            set
+            {
+                try
+                {
+                    using (RegistryKey registryKey = Registry.CurrentUser.CreateSubKey(RegistrySubKey))
+                    {
+                        registryKey.SetValue(RememberLastRowCountKey, value.ToString());
                     }
                 }
                 catch { }

--- a/src/ParquetFileViewer/FieldSelectionDialog.cs
+++ b/src/ParquetFileViewer/FieldSelectionDialog.cs
@@ -1,4 +1,5 @@
 ﻿using Parquet.Data;
+using Parquet.Schema;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/src/ParquetFileViewer/FieldSelectionDialog.cs
+++ b/src/ParquetFileViewer/FieldSelectionDialog.cs
@@ -53,9 +53,9 @@ namespace ParquetFileViewer
                     int locationX = 0;
                     int locationY = 5;
                     bool isFirst = true;
-                    HashSet<string> fieldNames = new HashSet<string>();
                     bool isClearingSelectAllCheckbox = false;
 
+                    var checkboxControls = new List<CheckBox>();
                     foreach (Field field in availableFields)
                     {
                         if (isFirst) //Add toggle all checkbox and some other setting changes
@@ -97,7 +97,6 @@ namespace ParquetFileViewer
                                             if (checkbox.Enabled)
                                             {
                                                 checkbox.Checked = selectAllCheckBox.Checked;
-                                                //this.PreSelectedFields.Remove((string)checkbox.Tag);
                                             }
                                         }
                                     }
@@ -108,57 +107,62 @@ namespace ParquetFileViewer
                             locationY += DynamicFieldCheckboxYIncrement;
                         }
 
-                        if (!fieldNames.Contains(field.Name.ToLowerInvariant())) //Normally two fields with the same name shouldn't exist but lets make sure
+                        bool isUnsupportedFieldType = UnsupportedSchemaTypes.Contains(field.SchemaType);
+                        var fieldCheckbox = new CheckBox()
                         {
-                            bool isUnsupportedFieldType = UnsupportedSchemaTypes.Contains(field.SchemaType);
-                            var fieldCheckbox = new CheckBox()
+                            Name = string.Concat("checkbox_", field.Name),
+                            Text = string.Concat(field.Name, isUnsupportedFieldType ? "(Unsupported)" : string.Empty),
+                            Tag = field.Name,
+                            Checked = preSelectedFields.Contains(field.Name),
+                            Location = new Point(locationX, locationY),
+                            AutoSize = true,
+                            Enabled = !isUnsupportedFieldType
+                        };
+                        fieldCheckbox.CheckedChanged += (object checkboxSender, EventArgs checkboxEventArgs) =>
+                        {
+                            var fieldCheckBox = (CheckBox)checkboxSender;
+
+                            if (fieldCheckBox.Checked)
                             {
-                                Name = string.Concat("checkbox_", field.Name),
-                                Text = string.Concat(field.Name, isUnsupportedFieldType ? "(Unsupported)" : string.Empty),
-                                Tag = field.Name,
-                                Checked = preSelectedFields.Contains(field.Name),
-                                Location = new Point(locationX, locationY),
-                                AutoSize = true,
-                                Enabled = !isUnsupportedFieldType
-                            };
-                            fieldCheckbox.CheckedChanged += (object checkboxSender, EventArgs checkboxEventArgs) =>
+                                this.PreSelectedFields.Add((string)fieldCheckBox.Tag);
+                            }
+                            else
                             {
-                                var fieldCheckBox = (CheckBox)checkboxSender;
-
-                                if (fieldCheckBox.Checked)
-                                {
-                                    this.PreSelectedFields.Add((string)fieldCheckBox.Tag);
-                                }
-                                else
-                                {
-                                    this.PreSelectedFields.Remove((string)fieldCheckBox.Tag);
-                                }
+                                this.PreSelectedFields.Remove((string)fieldCheckBox.Tag);
+                            }
 
 
-                                if (!fieldCheckBox.Checked)
+                            if (!fieldCheckBox.Checked)
+                            {
+                                foreach (Control control in this.fieldsPanel.Controls)
                                 {
-                                    foreach (Control control in this.fieldsPanel.Controls)
+                                    if (control.Tag.Equals(SelectAllCheckboxName) && control is CheckBox checkbox)
                                     {
-                                        if (control.Tag.Equals(SelectAllCheckboxName) && control is CheckBox checkbox)
+                                        if (checkbox.Enabled && checkbox.Checked)
                                         {
-                                            if (checkbox.Enabled && checkbox.Checked)
-                                            {
-                                                isClearingSelectAllCheckbox = true;
-                                                checkbox.Checked = false;
-                                                this.PreSelectedFields.Remove((string)fieldCheckBox.Tag);
-                                                isClearingSelectAllCheckbox = false;
-                                                break;
-                                            }
+                                            isClearingSelectAllCheckbox = true;
+                                            checkbox.Checked = false;
+                                            this.PreSelectedFields.Remove((string)fieldCheckBox.Tag);
+                                            isClearingSelectAllCheckbox = false;
+                                            break;
                                         }
                                     }
                                 }
-                            };
-                            this.fieldsPanel.Controls.Add(fieldCheckbox);
+                            }
+                        };
+                        checkboxControls.Add(fieldCheckbox);
 
-                            locationY += DynamicFieldCheckboxYIncrement;
-                            fieldNames.Add(field.Name.ToLowerInvariant());
-                        }
+                        locationY += DynamicFieldCheckboxYIncrement;
                     }
+
+                    //Disable fields with dupe names because we don't support case sensitive fields right now
+                    var duplicateFields = checkboxControls?.GroupBy(f => f.Text.ToUpperInvariant()).Where(g => g.Count() > 1).SelectMany(g => g).ToList();
+                    foreach(var duplicateField in duplicateFields)
+                    {
+                        duplicateField.Enabled = false;
+                    }
+
+                    this.fieldsPanel.Controls.AddRange(checkboxControls.ToArray<Control>());
                 }
             }
             catch (Exception ex)

--- a/src/ParquetFileViewer/MainForm.Designer.cs
+++ b/src/ParquetFileViewer/MainForm.Designer.cs
@@ -29,6 +29,7 @@ namespace ParquetFileViewer
         /// </summary>
         private void InitializeComponent()
         {
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.mainTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.recordsToLabel = new System.Windows.Forms.Label();
@@ -195,12 +196,12 @@ namespace ParquetFileViewer
             this.searchFilterLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.searchFilterLabel.AutoSize = true;
             this.mainTableLayoutPanel.SetColumnSpan(this.searchFilterLabel, 2);
-            this.searchFilterLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point);
+            this.searchFilterLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point);
             this.searchFilterLabel.LinkColor = System.Drawing.Color.Navy;
-            this.searchFilterLabel.Location = new System.Drawing.Point(4, 11);
+            this.searchFilterLabel.Location = new System.Drawing.Point(4, 9);
             this.searchFilterLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.searchFilterLabel.Name = "searchFilterLabel";
-            this.searchFilterLabel.Size = new System.Drawing.Size(97, 13);
+            this.searchFilterLabel.Size = new System.Drawing.Size(97, 16);
             this.searchFilterLabel.TabIndex = 7;
             this.searchFilterLabel.TabStop = true;
             this.searchFilterLabel.Text = "Filter Query (?):";
@@ -244,12 +245,23 @@ namespace ParquetFileViewer
             this.mainGridView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.mainGridView.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI Semibold", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.mainGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
             this.mainGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             this.mainTableLayoutPanel.SetColumnSpan(this.mainGridView, 10);
+            this.mainGridView.EnableHeadersVisualStyles = false;
             this.mainGridView.Location = new System.Drawing.Point(4, 38);
             this.mainGridView.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.mainGridView.Name = "mainGridView";
             this.mainGridView.ReadOnly = true;
+            this.mainGridView.RowHeadersWidth = 24;
             this.mainTableLayoutPanel.SetRowSpan(this.mainGridView, 2);
             this.mainGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
             this.mainGridView.Size = new System.Drawing.Size(936, 356);
@@ -513,6 +525,7 @@ namespace ParquetFileViewer
             // metadataViewerToolStripMenuItem
             // 
             this.metadataViewerToolStripMenuItem.Enabled = false;
+            this.metadataViewerToolStripMenuItem.Image = Properties.Resources.text_file_icon.ToBitmap();
             this.metadataViewerToolStripMenuItem.Name = "metadataViewerToolStripMenuItem";
             this.metadataViewerToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.M)));
             this.metadataViewerToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
@@ -531,14 +544,14 @@ namespace ParquetFileViewer
             // userGuideToolStripMenuItem
             // 
             this.userGuideToolStripMenuItem.Name = "userGuideToolStripMenuItem";
-            this.userGuideToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.userGuideToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
             this.userGuideToolStripMenuItem.Text = "User Guide";
             this.userGuideToolStripMenuItem.Click += new System.EventHandler(this.userGuideToolStripMenuItem_Click);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
             this.aboutToolStripMenuItem.Text = "&About...";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 

--- a/src/ParquetFileViewer/MainForm.Designer.cs
+++ b/src/ParquetFileViewer/MainForm.Designer.cs
@@ -29,7 +29,7 @@ namespace ParquetFileViewer
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.mainTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.recordsToLabel = new System.Windows.Forms.Label();
@@ -83,6 +83,7 @@ namespace ParquetFileViewer
             this.totalRowCountStatusBarLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.mainStatusStrip = new System.Windows.Forms.StatusStrip();
             this.exportFileDialog = new System.Windows.Forms.SaveFileDialog();
+            this.rememberRecordCountToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mainTableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.mainGridView)).BeginInit();
             this.mainMenuStrip.SuspendLayout();
@@ -246,14 +247,14 @@ namespace ParquetFileViewer
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainGridView.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI Semibold", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.mainGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Segoe UI Semibold", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.mainGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
             this.mainGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             this.mainTableLayoutPanel.SetColumnSpan(this.mainGridView, 10);
             this.mainGridView.EnableHeadersVisualStyles = false;
@@ -371,7 +372,8 @@ namespace ParquetFileViewer
             this.changeFieldsMenuStripButton,
             this.changeDateFormatToolStripMenuItem,
             this.columnSizingToolStripMenuItem,
-            this.parquetEngineToolStripMenuItem});
+            this.parquetEngineToolStripMenuItem,
+            this.rememberRecordCountToolStripMenuItem});
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
             this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
             this.editToolStripMenuItem.Text = "&Edit";
@@ -525,7 +527,6 @@ namespace ParquetFileViewer
             // metadataViewerToolStripMenuItem
             // 
             this.metadataViewerToolStripMenuItem.Enabled = false;
-            this.metadataViewerToolStripMenuItem.Image = Properties.Resources.text_file_icon.ToBitmap();
             this.metadataViewerToolStripMenuItem.Name = "metadataViewerToolStripMenuItem";
             this.metadataViewerToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.M)));
             this.metadataViewerToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
@@ -631,6 +632,15 @@ namespace ParquetFileViewer
             this.exportFileDialog.RestoreDirectory = true;
             this.exportFileDialog.Title = "Choose Save Location";
             // 
+            // rememberRecordCountToolStripMenuItem
+            // 
+            this.rememberRecordCountToolStripMenuItem.Checked = true;
+            this.rememberRecordCountToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.rememberRecordCountToolStripMenuItem.Name = "rememberRecordCountToolStripMenuItem";
+            this.rememberRecordCountToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
+            this.rememberRecordCountToolStripMenuItem.Text = "Remember Record Count";
+            this.rememberRecordCountToolStripMenuItem.Click += new System.EventHandler(this.rememberRecordCountToolStripMenuItem_Click);
+            // 
             // MainForm
             // 
             this.AllowDrop = true;
@@ -716,6 +726,7 @@ namespace ParquetFileViewer
         private System.Windows.Forms.ToolStripMenuItem iSO8601DateOnlyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem iSO8601Alt1ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem iSO8601Alt2ToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem rememberRecordCountToolStripMenuItem;
     }
 }
 

--- a/src/ParquetFileViewer/MainForm.cs
+++ b/src/ParquetFileViewer/MainForm.cs
@@ -21,7 +21,7 @@ namespace ParquetFileViewer
     {
         private const string WikiURL = "https://github.com/mukunku/ParquetViewer/wiki";
         private const int DefaultOffset = 0;
-        private const int DefaultRowCount = 1000;
+        private const int DefaultRowCountValue = 1000;
         private const int loadingPanelWidth = 200;
         private const int loadingPanelHeight = 200;
         private const string QueryUselessPartRegex = "^WHERE ";
@@ -89,17 +89,23 @@ namespace ParquetFileViewer
             }
         }
 
-        private int currentMaxRowCount = AppSettings.DefaultRowCount;
+        private int currentMaxRowCount = DefaultRowCount;
         private int CurrentMaxRowCount
         {
             get => this.currentMaxRowCount;
             set
             {
                 this.currentMaxRowCount = value;
-                AppSettings.DefaultRowCount = value;
+                DefaultRowCount = value;
                 if (this.IsAnyFileOpen)
                     LoadFileToGridview();
             }
+        }
+
+        private static int DefaultRowCount
+        {
+            get => AppSettings.LastRowCount ?? DefaultRowCountValue;
+            set => AppSettings.LastRowCount = value;
         }
 
         private bool IsAnyFileOpen
@@ -147,7 +153,7 @@ namespace ParquetFileViewer
             InitializeComponent();
             this.DefaultFormTitle = this.Text;
             this.offsetTextBox.SetTextQuiet(DefaultOffset.ToString());
-            this.recordCountTextBox.SetTextQuiet(AppSettings.DefaultRowCount.ToString());
+            this.recordCountTextBox.SetTextQuiet(DefaultRowCount.ToString());
             this.MainDataSource = new DataTable();
             this.OpenFilePath = null;
 
@@ -192,6 +198,11 @@ namespace ParquetFileViewer
                         break;
                     }
                 }
+
+                if (AppSettings.RememberLastRowCount)
+                    this.rememberRecordCountToolStripMenuItem.Checked = true;
+                else
+                    this.rememberRecordCountToolStripMenuItem.Checked = false;
             }
             catch (Exception ex)
             {
@@ -673,8 +684,8 @@ MULTIPLE CONDITIONS:
             this.OpenFilePath = filePath;
 
             this.offsetTextBox.SetTextQuiet(DefaultOffset.ToString());
-            this.currentMaxRowCount = AppSettings.DefaultRowCount;
-            this.recordCountTextBox.SetTextQuiet(AppSettings.DefaultRowCount.ToString());
+            this.currentMaxRowCount = DefaultRowCount;
+            this.recordCountTextBox.SetTextQuiet(DefaultRowCount.ToString());
             this.currentOffset = DefaultOffset;
 
             this.OpenFieldSelectionDialog(false);
@@ -1038,6 +1049,20 @@ MULTIPLE CONDITIONS:
         private void mainGridView_CellMouseLeave(object sender, DataGridViewCellEventArgs e)
         {
             this.dateOnlyFormatWarningToolTip.Hide(this);
+        }
+
+        private void rememberRecordCountToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                this.rememberRecordCountToolStripMenuItem.Checked = !this.rememberRecordCountToolStripMenuItem.Checked;
+                AppSettings.RememberLastRowCount = this.rememberRecordCountToolStripMenuItem.Checked;
+                AppSettings.LastRowCount = this.CurrentMaxRowCount;
+            }
+            catch (Exception ex)
+            {
+                this.ShowError(ex);
+            }
         }
     }
 }

--- a/src/ParquetFileViewer/MainForm.cs
+++ b/src/ParquetFileViewer/MainForm.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Parquet;
-using Parquet.Data.Rows;
 using ParquetFileViewer.Helpers;
 
 namespace ParquetFileViewer
@@ -143,9 +142,9 @@ namespace ParquetFileViewer
             }
         }
         private Panel loadingPanel = null;
-        private Parquet.Data.Schema openFileSchema;
+        private Parquet.Schema.ParquetSchema openFileSchema;
 
-        private ToolTip dateOnlyFormatWarningToolTip = new ToolTip();
+        private ToolTip dateOnlyFormatWarningToolTip = new();
         #endregion
 
         public MainForm()
@@ -496,7 +495,7 @@ MULTIPLE CONDITIONS:
             }
 
             var fields = this.openFileSchema.Fields;
-            if (fields != null && fields.Count > 0)
+            if (fields != null && fields.Count() > 0)
             {
                 if (AppSettings.AlwaysSelectAllFields && !forceOpenDialog)
                 {

--- a/src/ParquetFileViewer/MainForm.cs
+++ b/src/ParquetFileViewer/MainForm.cs
@@ -69,7 +69,19 @@ namespace ParquetFileViewer
             set
             {
                 this.selectedFields = value;
-                if (value != null && value.Count > 0)
+
+                //Check for duplicate fields (We don't support case sensitive field names unfortunately)
+                var duplicateFields = this.selectedFields?.GroupBy(f => f.ToUpperInvariant()).Where(g => g.Count() > 1).SelectMany(g => g).ToList();
+                if (duplicateFields?.Count() > 0)
+                {
+                    this.selectedFields = this.selectedFields.Where(f => !duplicateFields.Any(df => df.Equals(f, StringComparison.InvariantCultureIgnoreCase))).ToList();
+
+                    MessageBox.Show($"The following duplicate fields could not be loaded: {string.Join(',', duplicateFields)}. " +
+                            $"\r\n\r\nCase sensitive field names are not currently supported.", "Duplicate fields detected",
+                            MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+
+                if (value?.Count > 0)
                 {
                     LoadFileToGridview();
                 }
@@ -546,7 +558,7 @@ MULTIPLE CONDITIONS:
                         {
                             int i = 0;
                             var fieldGroups = new List<(int, List<string>)>();
-                            foreach (List<string> fields in UtilityMethods.Split(this.SelectedFields, (int)(this.selectedFields.Count / Environment.ProcessorCount)))
+                            foreach (List<string> fields in UtilityMethods.Split(this.SelectedFields, (int)(this.SelectedFields.Count / Environment.ProcessorCount)))
                             {
                                 fieldGroups.Add((i++, fields));
                             }

--- a/src/ParquetFileViewer/MainForm.cs
+++ b/src/ParquetFileViewer/MainForm.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Parquet;
+using Parquet.Data.Rows;
 using ParquetFileViewer.Helpers;
 
 namespace ParquetFileViewer
@@ -432,7 +433,8 @@ MULTIPLE CONDITIONS:
                     if (this.mainGridView.SelectedCells.Contains(((DataGridView)sender)[e.ColumnIndex, e.RowIndex]))
                         color = Color.White;
 
-                    TextRenderer.DrawText(e.Graphics, "NULL", font, e.CellBounds, color, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                    TextRenderer.DrawText(e.Graphics, "NULL", font, e.CellBounds, color, 
+                        TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.PreserveGraphicsClipping);
 
                     e.Handled = true;
                 }

--- a/src/ParquetFileViewer/MainForm.resx
+++ b/src/ParquetFileViewer/MainForm.resx
@@ -64,6 +64,34 @@
     <value>193, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="changeFieldsMenuStripButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAwBJREFUWEfd19mLjWEcwPEhu8i+71uWQUqRFMq+hFxYSvbBhDPWZM2eEELJtcKV
+        ohTKheXGjGFQbjCWKdsFf4Lv93heTqfXmVdzjuRXn4zxvO/zvM/y+z2K/qlIVbxTeyzEUiwJ/Hn4Bv69
+        rPyHvMfaZ6+jAdjhQUzFtPDnIuwJRiM8lcdY+7Q6GsCK0NFq1C+rrPF3Y3EXNzEQrdEfAxKwXTvUQ+gt
+        JrIGsAMPMBKb8QLn4PLoOj7iQwK2u4FOCL3FRMYASjAZ5/ES9+ESbEVTNMIUrPsDLmVjhN5iImMATv08
+        TMBZDEc/HIcDCE/kOdZUvYoG4CY7gwPBfpzEKuRex7qGLw+duM490D3oCqc+tCxQ2AFGwak/lOEUXJq/
+        MgNuwvlohpZoAY/SsfC70LoA4cuxEhOjjsLv2sDk5AAaYhyWwyNbG9u5oWtfQhsgbgBt4VJ4CjrAc/0F
+        nxOw3S10Rvqdvw0bwN0eNwOH0TxV8da/d8QQFCdgO5NQ7fvHBlgMO5uOWZgJp9GNmDuZ1DV8OZxuE5EV
+        MWImLE5RBVOPCj8ApjldfCbBpYh0Q7pNQaL0VzleAKfbpVgG7wKbsDP8PBRF6x+9CU/mKTJqgafACjgH
+        6Y2DQbACPoQV0tzQE70SsF0rpN//28gqx575e7AImZQe4zL6wtp+FTV4n4DtriFxOfYYzsBF+MVPsAUb
+        0QSehNmwPCc1Fz4beouJrHLsNcw7wRVYG0wiR1G4VFzy5GU0AHf8BeyDS+H1zHLsl9RHeKIA4ctDJ35x
+        H/QO3Ei5p7CuUfr854XE1Bl9+d7AzOipMEeks+G68urwZJ4iYw9YjtdjMKJLyTBYjDyK7o2CDsBjeAJe
+        Svxav7oMVTgCq6H3RE+Cs1Ib241AA4TeYiJjACYiT4L/DzDzXUIltsMBOYDb+IavCdjuDrog9BYTWUvg
+        BWI3PsHruV/gXvAYuklNSNaLpExouU/QmqqftcAZMOmYjHZhDLzXn8ZfKcfmbwegFCxE2zAe6Tb/URQV
+        fQcn/rzir4d0CAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="changeDateFormatToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAKxJREFUWEftjssKAjEQBAN69+b/f6UnRUfZDjHzMInphYUU1GGnO2ynRcBFfG6O
+        gvfnz1cn5Y9HRvz1/iruPuAkvouloL63Crz7F3WpLFpZiyDKMnfRK9X3VkGUZaKSlbUIoixjlZgqrBJT
+        hVViqnCDyawBXQNulSWjWdcA3BiZwg0mc6wBuDEyRVRmZAo3mMyxBuDGyBRRmZEp3GAya8DPAXv4EE2s
+        MsPFRkovkH56TwbQBuIAAAAASUVORK5CYII=
+</value>
+  </data>
   <data name="newToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -120,34 +148,6 @@
         GMqEwJY3ymCguirMTyaIfUaMTsbg+xmMTs5Cyb2KPaYWDut2u6DXFwkBraXjDtavTQKCT+ffxLvAHALT
         i7hQbEeswcXgJsQm3IMuPl8IMjOGWN9LHN5q9GDLDhmP23rga+9DR3c/el8PYq/ZCo2+AXEM3q6th1ab
         IwSUkyd6+HrShtGS0DvTU9G0aWDUM51KRfDOuKxowb9FktYATrQ4xbl82G8AAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="changeFieldsMenuStripButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAwBJREFUWEfd19mLjWEcwPEhu8i+71uWQUqRFMq+hFxYSvbBhDPWZM2eEELJtcKV
-        ohTKheXGjGFQbjCWKdsFf4Lv93heTqfXmVdzjuRXn4zxvO/zvM/y+z2K/qlIVbxTeyzEUiwJ/Hn4Bv69
-        rPyHvMfaZ6+jAdjhQUzFtPDnIuwJRiM8lcdY+7Q6GsCK0NFq1C+rrPF3Y3EXNzEQrdEfAxKwXTvUQ+gt
-        JrIGsAMPMBKb8QLn4PLoOj7iQwK2u4FOCL3FRMYASjAZ5/ES9+ESbEVTNMIUrPsDLmVjhN5iImMATv08
-        TMBZDEc/HIcDCE/kOdZUvYoG4CY7gwPBfpzEKuRex7qGLw+duM490D3oCqc+tCxQ2AFGwak/lOEUXJq/
-        MgNuwvlohpZoAY/SsfC70LoA4cuxEhOjjsLv2sDk5AAaYhyWwyNbG9u5oWtfQhsgbgBt4VJ4CjrAc/0F
-        nxOw3S10Rvqdvw0bwN0eNwOH0TxV8da/d8QQFCdgO5NQ7fvHBlgMO5uOWZgJp9GNmDuZ1DV8OZxuE5EV
-        MWImLE5RBVOPCj8ApjldfCbBpYh0Q7pNQaL0VzleAKfbpVgG7wKbsDP8PBRF6x+9CU/mKTJqgafACjgH
-        6Y2DQbACPoQV0tzQE70SsF0rpN//28gqx575e7AImZQe4zL6wtp+FTV4n4DtriFxOfYYzsBF+MVPsAUb
-        0QSehNmwPCc1Fz4beouJrHLsNcw7wRVYG0wiR1G4VFzy5GU0AHf8BeyDS+H1zHLsl9RHeKIA4ctDJ35x
-        H/QO3Ei5p7CuUfr854XE1Bl9+d7AzOipMEeks+G68urwZJ4iYw9YjtdjMKJLyTBYjDyK7o2CDsBjeAJe
-        Svxav7oMVTgCq6H3RE+Cs1Ib241AA4TeYiJjACYiT4L/DzDzXUIltsMBOYDb+IavCdjuDrog9BYTWUvg
-        BWI3PsHruV/gXvAYuklNSNaLpExouU/QmqqftcAZMOmYjHZhDLzXn8ZfKcfmbwegFCxE2zAe6Tb/URQV
-        fQcn/rzir4d0CAAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="changeDateFormatToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAKxJREFUWEftjssKAjEQBAN69+b/f6UnRUfZDjHzMInphYUU1GGnO2ynRcBFfG6O
-        gvfnz1cn5Y9HRvz1/iruPuAkvouloL63Crz7F3WpLFpZiyDKMnfRK9X3VkGUZaKSlbUIoixjlZgqrBJT
-        hVViqnCDyawBXQNulSWjWdcA3BiZwg0mc6wBuDEyRVRmZAo3mMyxBuDGyBRRmZEp3GAya8DPAXv4EE2s
-        MsPFRkovkH56TwbQBuIAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="getSQLCreateTableScriptToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/src/ParquetFileViewer/MainForm.resx
+++ b/src/ParquetFileViewer/MainForm.resx
@@ -124,48 +124,48 @@
   </data>
   <data name="changeFieldsMenuStripButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAMASURBVFhH3dfZi41hHMDxIbvIvu9blkFKkRTKvoRcWEr2
-        wYQz1mTNnhBCybXClaIUyoXlxoxhUG4wlinbBX+C7/d4Xk6n15lXc47kV5+M8bzv87zP8vs9iv6pSFW8
-        U3ssxFIsCfx5+Ab+vaz8h7zH2mevowHY4UFMxbTw5yLsCUYjPJXHWPu0OhrAitDRatQvq6zxd2NxFzcx
-        EK3RHwMSsF071EPoLSayBrADDzASm/EC5+Dy6Do+4kMCtruBTgi9xUTGAEowGefxEvfhEmxFUzTCFKz7
-        Ay5lY4TeYiJjAE79PEzAWQxHPxyHAwhP5DnWVL2KBuAmO4MDwX6cxCrkXse6hi8PnbjOPdA96AqnPrQs
-        UNgBRsGpP5ThFFyavzIDbsL5aIaWaAGP0rHwu9C6AOHLsRITo47C79rA5OQAGmIclsMjWxvbuaFrX0Ib
-        IG4AbeFSeAo6wHP9BZ8TsN0tdEb6nb8NG8DdHjcDh9E8VfHWv3fEEBQnYDuTUO37xwZYDDubjlmYCafR
-        jZg7mdQ1fDmcbhORFTFiJixOUQVTjwo/AKY5XXwmwaWIdEO6TUGi9Fc5XgCn26VYBu8Cm7Az/DwUResf
-        vQlP5ikyaoGnwAo4B+mNg0GwAj6EFdLc0BO9ErBdK6Tf/9vIKsee+XuwCJmUHuMy+sLafhU1eJ+A7a4h
-        cTn2GM7ARfjFT7AFG9EEnoTZsDwnNRc+G3qLiaxy7DXMO8EVWBtMIkdRuFRc8uRlNAB3/AXsg0vh9cxy
-        7JfUR3iiAOHLQyd+cR/0DtxIuaewrlH6/OeFxNQZffnewMzoqTBHpLPhuvLq8GSeImMPWI7XYzCiS8kw
-        WIw8iu6Ngg7AY3gCXkr8Wr+6DFU4Aquh90RPgrNSG9uNQAOE3mIiYwAmIk+C/w8w811CJbbDATmA2/iG
-        rwnY7g66IPQWE1lL4AViNz7B67lf4F7wGLpJTUjWi6RMaLlP0Jqqn7XAGTDpmIx2YQy815/GXynH5m8H
-        oBQsRNswHuk2/1EUFX0HJ/684q+HdAgAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAwBJREFUWEfd19mLjWEcwPEhu8i+71uWQUqRFMq+hFxYSvbBhDPWZM2eEELJtcKV
+        ohTKheXGjGFQbjCWKdsFf4Lv93heTqfXmVdzjuRXn4zxvO/zvM/y+z2K/qlIVbxTeyzEUiwJ/Hn4Bv69
+        rPyHvMfaZ6+jAdjhQUzFtPDnIuwJRiM8lcdY+7Q6GsCK0NFq1C+rrPF3Y3EXNzEQrdEfAxKwXTvUQ+gt
+        JrIGsAMPMBKb8QLn4PLoOj7iQwK2u4FOCL3FRMYASjAZ5/ES9+ESbEVTNMIUrPsDLmVjhN5iImMATv08
+        TMBZDEc/HIcDCE/kOdZUvYoG4CY7gwPBfpzEKuRex7qGLw+duM490D3oCqc+tCxQ2AFGwak/lOEUXJq/
+        MgNuwvlohpZoAY/SsfC70LoA4cuxEhOjjsLv2sDk5AAaYhyWwyNbG9u5oWtfQhsgbgBt4VJ4CjrAc/0F
+        nxOw3S10Rvqdvw0bwN0eNwOH0TxV8da/d8QQFCdgO5NQ7fvHBlgMO5uOWZgJp9GNmDuZ1DV8OZxuE5EV
+        MWImLE5RBVOPCj8ApjldfCbBpYh0Q7pNQaL0VzleAKfbpVgG7wKbsDP8PBRF6x+9CU/mKTJqgafACjgH
+        6Y2DQbACPoQV0tzQE70SsF0rpN//28gqx575e7AImZQe4zL6wtp+FTV4n4DtriFxOfYYzsBF+MVPsAUb
+        0QSehNmwPCc1Fz4beouJrHLsNcw7wRVYG0wiR1G4VFzy5GU0AHf8BeyDS+H1zHLsl9RHeKIA4ctDJ35x
+        H/QO3Ei5p7CuUfr854XE1Bl9+d7AzOipMEeks+G68urwZJ4iYw9YjtdjMKJLyTBYjDyK7o2CDsBjeAJe
+        Svxav7oMVTgCq6H3RE+Cs1Ib241AA4TeYiJjACYiT4L/DzDzXUIltsMBOYDb+IavCdjuDrog9BYTWUvg
+        BWI3PsHruV/gXvAYuklNSNaLpExouU/QmqqftcAZMOmYjHZhDLzXn8ZfKcfmbwegFCxE2zAe6Tb/URQV
+        fQcn/rzir4d0CAAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="changeDateFormatToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACsSURBVFhH7Y7LCgIxEAQDevfm/3+lJ0VH2Q4x8zCJ6YWF
-        FNRhpztsp0XARXxujoL3589XJ+WPR0b89f4q7j7gJL6LpaC+twq8+xd1qSxaWYsgyjJ30SvV91ZBlGWi
-        kpW1CKIsY5WYKqwSU4VVYqpwg8msAV0DbpUlo1nXANwYmcINJnOsAbgxMkVUZmQKN5jMsQbgxsgUUZmR
-        KdxgMmvAzwF7+BBNrDLDxUZKL5B+ek8G0AbiAAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAKxJREFUWEftjssKAjEQBAN69+b/f6UnRUfZDjHzMInphYUU1GGnO2ynRcBFfG6O
+        gvfnz1cn5Y9HRvz1/iruPuAkvouloL63Crz7F3WpLFpZiyDKMnfRK9X3VkGUZaKSlbUIoixjlZgqrBJT
+        hVViqnCDyawBXQNulSWjWdcA3BiZwg0mc6wBuDEyRVRmZAo3mMyxBuDGyBRRmZEp3GAya8DPAXv4EE2s
+        MsPFRkovkH56TwbQBuIAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="getSQLCreateTableScriptToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK6SURBVFhH7VdNaxNRFI1DrClU2pXgoj/AplL6ke+kSQtm
-        kSCkiyAWxE1tLQRiWttgpGiXXQaqJYuCSKS7CFKMpWgX/QARTTOSxo8sBRfiwh8wuZ338l76ZvJmkiZF
-        XeTAgZl775xz5k5mIIb/HuXXhgvwygDwRuaWinId9cmoJnoe9sD6wbrXFDdB13KX1xg1QmAtAKhORpSQ
-        ti//rppkDfBr9y4c5d6BmM9BXixgFnJ78OPgEe7TWWlTeE8kmgc1zYufQRTFhonmaRgipYtYJublbgAJ
-        8AwaZaMBNIEEfu4nuOL1+GcncDYboJSyJvj6MQOH4hHX8FD8AqUPz6G8JVSvQSRSzYEVaojoue/1A5Qe
-        V2tEShcNbUCXpeWKKUvSI1LNQWGix3aAdoB2ADmAVIxvTE9HNnw+PzaF7Uu4h4U04PcH9QPWGGmRbEAq
-        3itYrW5wu8fA4xkH6dPNt0SqBmgGcWDAoh2Ca6YinmMfwfcEmM2DWNxm89SIp1Kp89SccnjYwQ/BM1ST
-        jMohKgHK3x54WXHSxkin01fZHqLT6eWbI/AM1URzrFEkEp2h4i7XiXg8vnSd1inR4yJtPniGapZ3+yfU
-        wixjsfsTSGtoyK6oo3NsoodyceEiz1RNNMuKU87ORq+EwzeeoN8CW7fZ6tw5D7DJN6eUdswpMorhdo/D
-        6uraC9bYanWd3rhV2O0nd09Kfw8jIw6w20flTTy9NTl5Gwfo6xvUD9Ix13EmSdHr5fNdw1roeGpq5g7d
-        hMXi1PYIPwu3HMDjGYNQSKlDzSnRdkhLic7FzpYCuFw++Q5d++RUAXUIh4PzETLOG5sOgESDwZDu9bUh
-        RpXz8y/nsuTwVEBiTqevofBoS2wIUq6gO9GNC8KiACvZFY+wIEAik4DepV5NcfRVSyaTdf+YsmDMz1Uq
-        /xwGwzFIl5WH4imekwAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAArpJREFUWEftV01rE1EUjUOsKVTaleCiP8CmUvqR76RJC2aRIKSLIBbETW0tBGJa
+        22CkaJddBqoli4JIpLsIUoylaBf9ABFNM5LGjywFF+LCHzC5nffyXvpm8maSJkVd5MCBmXvvnHPmTmYg
+        hv8e5deGC/DKAPBG5paKch31yagmeh72wPrButcUN0HXcpfXGDVCYC0AqE5GlJC2L/+ummQN8Gv3Lhzl
+        3oGYz0FeLGAWcnvw4+AR7tNZaVN4TySaBzXNi59BFMWGieZpGCKli1gm5uVuAAnwDBplowE0gQR+7ie4
+        4vX4ZydwNhuglLIm+PoxA4fiEdfwUPwCpQ/PobwlVK9BJFLNgRVqiOi57/UDlB5Xa0RKFw1tQJel5Yop
+        S9IjUs1BYaLHdoB2gHYAOYBUjG9MT0c2fD4/NoXtS7iHhTTg9wf1A9YYaZFsQCreK1itbnC7x8DjGQfp
+        0823RKoGaAZxYMCiHYJrpiKeYx/B9wSYzYNY3Gbz1IinUqnz1JxyeNjBD8EzVJOMyiEqAcrfHnhZcdLG
+        SKfTV9keotPp5Zsj8AzVRHOsUSQSnaHiLteJeDy+dJ3WKdHjIm0+eIZqlnf7J9TCLGOx+xNIa2jIrqij
+        c2yih3Jx4SLPVE00y4pTzs5Gr4TDN56g3wJbt9nq3DkPsMk3p5R2zCkyiuF2j8Pq6toL1thqdZ3euFXY
+        7Sd3T0p/DyMjDrDbR+VNPL01OXkbB+jrG9QP0jHXcSZJ0evl813DWuh4amrmDt2ExeLU9gg/C7ccwOMZ
+        g1BIqUPNKdF2SEuJzsXOlgK4XD75Dl375FQBdQiHg/MRMs4bmw6ARIPBkO71tSFGlfPzL+ey5PBUQGJO
+        p6+h8GhLbAhSrqA70Y0LwqIAK9kVj7AgQCKTgN6lXk1x9FVLJpN1/5iyYMzPVSr/HAbDMUiXlYfiKZ6T
+        AAAAAElFTkSuQmCC
 </value>
   </data>
   <metadata name="mainStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/ParquetFileViewer/ParquetFileViewer.csproj
+++ b/src/ParquetFileViewer/ParquetFileViewer.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Parquet.Net" Version="4.1.2" />
+    <PackageReference Include="Parquet.Net" Version="4.4.4" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/ParquetFileViewer/ParquetFileViewer.csproj
+++ b/src/ParquetFileViewer/ParquetFileViewer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>ParquetViewer</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -33,7 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Parquet.Net" Version="4.1.0" />
+    <PackageReference Include="Parquet.Net" Version="4.1.2" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/ParquetFileViewer/Properties/AssemblyInfo.cs
+++ b/src/ParquetFileViewer/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.0.0")]
+[assembly: AssemblyVersion("2.5.1.0")]

--- a/src/ParquetFileViewer/Properties/AssemblyInfo.cs
+++ b/src/ParquetFileViewer/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.4.2.0")]
+[assembly: AssemblyVersion("2.5.0.0")]


### PR DESCRIPTION
This PR bumps the utility's .net version to 7. I'm not %100 sure this is the best choice because .net 6 is the LTS version and .net 7 will only be supported until May 2024. But after the bug report in #64 I decided what the hay. 

.net 7 was officially released in Nov 2022 so it's possible a lot of people don't have the framework on their machines yet. So going forward I will always include a self contained executable with the latest version of the app. I will remove it from older versions after a new version is released because each such executable is 150MB+ in size.

If anyone has any feedback please feel free to comment on this PR.