### PR TITLE
V2.8.0.2 release

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Apache.Arrow" Version="13.0.0" />
-    <PackageVersion Include="Parquet.Net" Version="4.16.3" />
+    <PackageVersion Include="Parquet.Net" Version="4.16.4" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="6.0.0" />

--- a/src/ParquetViewer.Engine/ParquetEngine.Processor.cs
+++ b/src/ParquetViewer.Engine/ParquetEngine.Processor.cs
@@ -118,9 +118,9 @@ namespace ParquetViewer.Engine
             int rowIndex = rowBeginIndex;
 
             int skippedRecords = 0;
-            var dataColumn = await groupReader.ReadColumnAsync(field.DataField ?? throw new Exception($"Pritimive field {field.Path} is missing its data field"), cancellationToken);
+            var dataColumn = await groupReader.ReadColumnAsync(field.DataField ?? throw new Exception($"Pritimive field `{field.Path}` is missing its data field"), cancellationToken);
 
-            var fieldIndex = dataTable.Columns[field.DataField.Path.ToString()]?.Ordinal ?? throw new Exception($"Column {field.Path} is missing");
+            var fieldIndex = dataTable.Columns[field.DataField.Path.ToString()]?.Ordinal ?? throw new Exception($"Column `{field.Path}` is missing");
             foreach (var value in dataColumn.Data)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -165,11 +165,11 @@ namespace ParquetViewer.Engine
             }
             catch (Exception ex)
             {
-                throw new UnsupportedFieldException($"Cannot load field '{field.Path}. Invalid List type.'", ex);
+                throw new UnsupportedFieldException($"Cannot load field `{field.Path}`. Invalid List type.", ex);
             }
 
             if (itemField.Children.Any())
-                throw new UnsupportedFieldException($"Cannot load field '{field.Path}'. Nested list types are not supported");
+                throw new UnsupportedFieldException($"Cannot load field `{field.Path}`. Nested list types are not supported.");
 
             int rowIndex = rowBeginIndex;
 
@@ -238,7 +238,7 @@ namespace ParquetViewer.Engine
             var valueField = keyValueField.GetChild("value");
 
             if (keyField.Children.Any() || valueField.Children.Any())
-                throw new UnsupportedFieldException($"Cannot load field '{field.Path}'. Nested map types are not supported");
+                throw new UnsupportedFieldException($"Cannot load field `{field.Path}`. Nested map types are not supported");
 
             int rowIndex = rowBeginIndex;
 
@@ -267,7 +267,7 @@ namespace ParquetViewer.Engine
 
                 bool isMapTypeValid = keyDataColumn.Data.Length == valueDataColumn.Data.Length;
                 if (!isMapTypeValid)
-                    throw new UnsupportedFieldException($"{field.Path} is malformed and cannot be loaded");
+                    throw new UnsupportedFieldException($"`{field.Path}` is malformed and cannot be loaded");
 
                 var key = keyDataColumn.Data.GetValue(i) ?? DBNull.Value;
                 var value = valueDataColumn.Data.GetValue(i) ?? DBNull.Value;
@@ -316,7 +316,7 @@ namespace ParquetViewer.Engine
             }
 
             var rowIndex = rowBeginIndex;
-            var fieldIndex = dataTable.Columns[field.Path]?.Ordinal ?? throw new Exception($"Column {field.Path} is missing");
+            var fieldIndex = dataTable.Columns[field.Path]?.Ordinal ?? throw new Exception($"Column `{field.Path}` is missing");
             for (var i = 0; i < structFieldDataTable.Rows.Count; i++)
             {
                 DataRow datarow = GetRow(dataTable, rowIndex);

--- a/src/ParquetViewer.Engine/ParquetEngine.cs
+++ b/src/ParquetViewer.Engine/ParquetEngine.cs
@@ -39,7 +39,7 @@ namespace ParquetViewer.Engine
 
             foreach (var dataField in Schema.GetDataFields())
             {
-                var field = thriftSchemaTree.GetChild(dataField.Path.FirstPart ?? throw new Exception($"Field has no schema path: {dataField.Name}"));
+                var field = thriftSchemaTree.GetChild(dataField.Path.FirstPart ?? throw new Exception($"Field has no schema path: `{dataField.Name}`"));
                 for (var i = 1; i < dataField.Path.Length; i++)
                 {
                     field = field.GetChild(dataField.Path[i]);

--- a/src/ParquetViewer.Engine/ParquetSchemaElement.cs
+++ b/src/ParquetViewer.Engine/ParquetSchemaElement.cs
@@ -40,7 +40,7 @@ namespace ParquetViewer.Engine
             }
 
             ParquetSchemaElement GetChildImpl(string? name) => name is not null && _children.TryGetValue(name, out var result)
-                ? result : throw new Exception($"Field schema path not found: {Path}/{name}");
+                ? result : throw new Exception($"Field schema path not found: `{Path}/{name}`");
         }
 
         public ParquetSchemaElement GetImmediateChildOrSingle(string name)
@@ -55,7 +55,7 @@ namespace ParquetViewer.Engine
                 return _children.First().Value;
             }
 
-            throw new Exception($"Field schema path not found: {Path}/{name}");
+            throw new Exception($"Field schema path not found: `{Path}/{name}`");
         }
     }
 }

--- a/src/ParquetViewer/Analytics/AllEvents.cs
+++ b/src/ParquetViewer/Analytics/AllEvents.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 namespace ParquetViewer.Analytics
 {
@@ -140,16 +141,33 @@ namespace ParquetViewer.Analytics
 
     public class ExceptionEvent : AmplitudeEvent
     {
+        public const string MASK_SENTINEL = "*****";
+
         private const string EVENT_TYPE = "exception.thrown";
 
         [JsonIgnore]
         public System.Exception Exception { get; set; }
 
-        public string Message => Exception?.Message;
+        public string Message
+        {
+            get
+            {
+                var message = Exception?.Message;
+
+                if (string.IsNullOrWhiteSpace(message))
+                    return message;
+
+                //Mask sensitive text that is wrapped with ` `
+                message = Regex.Replace(message, "`[^`]+`", MASK_SENTINEL);
+                return message;
+            }
+        }
+            
         public string StackTrace => Exception?.StackTrace?.ToString();
         public string InnerException => Exception?.InnerException?.ToString();
 
-        public ExceptionEvent() : base(EVENT_TYPE)
+        public ExceptionEvent(AmplitudeConfiguration? amplitudeConfiguration = null) 
+            : base(EVENT_TYPE, amplitudeConfiguration)
         {
 
         }

--- a/src/ParquetViewer/Analytics/AmplitudeConfiguration.cs
+++ b/src/ParquetViewer/Analytics/AmplitudeConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Net.Http;
+
+namespace ParquetViewer.Analytics
+{
+    public readonly struct AmplitudeConfiguration
+    {
+        internal readonly string ApiKey { get; }
+        public readonly Func<HttpMessageHandler> HttpMessageHandlerProvider { get; }
+        public readonly IConsentProvider ConsentProvider { get; }
+
+        public AmplitudeConfiguration(string apiKey, Func<HttpMessageHandler> httpMessageHandlerProvider, IConsentProvider consentProvider)
+        {
+            if (apiKey is null) throw new ArgumentNullException(nameof(apiKey));
+            if (httpMessageHandlerProvider is null) throw new ArgumentNullException(nameof(httpMessageHandlerProvider));
+            if (consentProvider is null) throw new ArgumentNullException(nameof(consentProvider));
+
+            ApiKey = apiKey;
+            HttpMessageHandlerProvider = httpMessageHandlerProvider;
+            ConsentProvider = consentProvider;
+        }
+    }
+}

--- a/src/ParquetViewer/Analytics/AppSettingsConsentProvider.cs
+++ b/src/ParquetViewer/Analytics/AppSettingsConsentProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace ParquetViewer.Analytics
+{
+    public class AppSettingsConsentProvider : IConsentProvider
+    {
+        public bool AnalyticsDataGatheringConsent => AppSettings.AnalyticsDataGatheringConsent;
+    }
+}

--- a/src/ParquetViewer/Analytics/IConsentProvider.cs
+++ b/src/ParquetViewer/Analytics/IConsentProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace ParquetViewer.Analytics
+{
+    public interface IConsentProvider
+    {
+        public bool AnalyticsDataGatheringConsent { get; }
+    }
+}

--- a/src/ParquetViewer/MainForm.Helpers.cs
+++ b/src/ParquetViewer/MainForm.Helpers.cs
@@ -326,8 +326,15 @@ namespace ParquetViewer
                     //Stringify and copy the data
                     foreach (DataRow row in data.Rows)
                     {
-                        var value = (byte[])row[tempColumnName];
-                        row[columnName] = BitConverter.ToString(value);
+                        if (row[tempColumnName] is null || row[tempColumnName] == DBNull.Value)
+                        {
+                            row[columnName] = DBNull.Value;
+                        }
+                        else
+                        {
+                            var value = (byte[])row[tempColumnName];
+                            row[columnName] = BitConverter.ToString(value);
+                        }
                     }
 
                     //remove the array column

--- a/src/ParquetViewer/Properties/AssemblyInfo.cs
+++ b/src/ParquetViewer/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.Versioning;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.8.0.1")]
+[assembly: AssemblyVersion("2.8.0.2")]


### PR DESCRIPTION
Opening a hotfix PR to v2.8.0. 

Fixes:
* null `byte[]` types are now correctly handled
* exception logging logic has been modified to strip field names