### PR TITLE
Improve error tracking by recording relative paths for skipped files (#104)

### DIFF
--- a/src/ParquetViewer.Engine/ParquetEngine.cs
+++ b/src/ParquetViewer.Engine/ParquetEngine.cs
@@ -134,7 +134,7 @@ namespace ParquetViewer.Engine
                 }
                 catch (Exception ex)
                 {
-                    skippedFiles.Add(Path.GetFileName(file), ex);
+                    skippedFiles.Add(Path.GetRelativePath(folderPath, file), ex);
                 }
             }
 


### PR DESCRIPTION
Modified the catch to use the relative path instead of the file name for #104 