### PR TITLE
V3.1.0 Release

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -32,8 +32,6 @@ jobs:
       run: dotnet test src/ParquetViewer.sln --no-build --logger trx
 
     - name: Test Report
-      uses: bibipkins/dotnet-test-reporter@v1.4.1
+      uses: EnricoMi/publish-unit-test-result-action@v2
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        comment-title: 'Unit Test Results'
-        results-path: ./src/ParquetViewer.Tests/TestResults/*.trx
+        files: src/ParquetViewer.Tests/TestResults/*.trx

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -22,7 +22,7 @@ jobs:
           src
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4.0.1
       with:
         dotnet-version: '8.0.x'
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,6 +6,10 @@ on:
    - master
  pull_request:
 
+permissions:
+  checks: write
+  pull-requests: write
+
 jobs:
  test:
     runs-on: windows-latest
@@ -32,6 +36,9 @@ jobs:
       run: dotnet test src/ParquetViewer.sln --no-build --logger trx
 
     - name: Test Report
-      uses: EnricoMi/publish-unit-test-result-action/windows@v2
+      uses: bibipkins/dotnet-test-reporter@v1.4.1
       with:
-        files: src/ParquetViewer.Tests/TestResults/*.trx
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-title: 'Unit Test Results'
+        results-path: ./src/ParquetViewer.Tests/TestResults/*.trx
+

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -32,6 +32,6 @@ jobs:
       run: dotnet test src/ParquetViewer.sln --no-build --logger trx
 
     - name: Test Report
-      uses: EnricoMi/publish-unit-test-result-action@v2
+      uses: EnricoMi/publish-unit-test-result-action/windows@v2
       with:
         files: src/ParquetViewer.Tests/TestResults/*.trx

--- a/.gitignore
+++ b/.gitignore
@@ -350,5 +350,3 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
-/src/ParquetFileViewer/FodyWeavers.xml
-/src/ParquetFileViewer/FodyWeavers.xsd

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Checkout the [ParquetViewer Analytics Dashboard](https://app.amplitude.com/analy
 [^1]: Full privacy policy here: https://github.com/mukunku/ParquetViewer/wiki/Privacy-Policy
 
 # Technical Details
-The latest version of this project was written in C# using Microsoft Visual Studio Community 2022 v17.9.6 and .NET 8
+The latest version of this project was written in C# using Microsoft Visual Studio Community 2022 v17.10.3 and .NET 8
 
 # Acknowledgements
 This utility would not be possible without: https://github.com/aloneguid/parquet-dotnet

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,14 +3,14 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Apache.Arrow" Version="16.0.0" />
-    <PackageVersion Include="Parquet.Net" Version="4.23.5" />
+    <PackageVersion Include="Apache.Arrow" Version="16.1.0" />
+    <PackageVersion Include="Parquet.Net" Version="4.24.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageVersion Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageVersion Include="xunit" Version="2.8.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/ParquetViewer.Engine/ParquetEngine.cs
+++ b/src/ParquetViewer.Engine/ParquetEngine.cs
@@ -70,11 +70,6 @@ namespace ParquetViewer.Engine
             OpenFileOrFolderPath = fileOrFolderPath;
         }
 
-        public Task<ParquetEngine> CloneAsync(CancellationToken cancellationToken)
-        {
-            return OpenFileOrFolderAsync(this.OpenFileOrFolderPath, cancellationToken);
-        }
-
         public static Task<ParquetEngine> OpenFileOrFolderAsync(string fileOrFolderPath, CancellationToken cancellationToken)
         {
             if (File.Exists(fileOrFolderPath)) //Handles null

--- a/src/ParquetViewer.Engine/ParquetEngine.cs
+++ b/src/ParquetViewer.Engine/ParquetEngine.cs
@@ -195,7 +195,7 @@ namespace ParquetViewer.Engine
                         file.EndsWith(".parquet.gz")
                 );
 
-            if (parquetFiles.Count() == 0)
+            if (!parquetFiles.Any())
             {
                 //Check for extensionless files
                 parquetFiles = Directory.EnumerateFiles(folderPath, "*", SearchOption.AllDirectories);
@@ -221,19 +221,6 @@ namespace ParquetViewer.Engine
             }
         }
 
-        public void Dispose()
-        {
-            if (_parquetFiles is not null)
-            {
-                foreach (var parquetFile in _parquetFiles)
-                {
-                    try
-                    {
-                        parquetFile?.Dispose();
-                    }
-                    catch { /* Swallow */ }
-                }
-            }
-        }
+        public void Dispose() => EZDispose(_parquetFiles);
     }
 }

--- a/src/ParquetViewer.Engine/Types/StructValue.cs
+++ b/src/ParquetViewer.Engine/Types/StructValue.cs
@@ -51,7 +51,7 @@ namespace ParquetViewer.Engine.Types
             }
         }
 
-        private static void WriteValue(Utf8JsonWriter jsonWriter, object value, bool truncateForDisplay)
+        public static void WriteValue(Utf8JsonWriter jsonWriter, object value, bool truncateForDisplay)
         {
             if (value is null)
             {

--- a/src/ParquetViewer.Tests/ParquetViewer.Tests.csproj
+++ b/src/ParquetViewer.Tests/ParquetViewer.Tests.csproj
@@ -4,32 +4,23 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
-
     <PlatformTarget>x64</PlatformTarget>
-
     <Configurations>Debug;Release;Release_SelfContained</Configurations>
-
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <LangVersion>default</LangVersion>
     <Optimize>True</Optimize>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_SelfContained|AnyCPU'">
     <LangVersion>default</LangVersion>
     <Optimize>True</Optimize>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <LangVersion>default</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="RichardSzalay.MockHttp" />
@@ -43,12 +34,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\ParquetViewer.Engine\ParquetViewer.Engine.csproj" />
     <ProjectReference Include="..\ParquetViewer\ParquetViewer.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="Data\COLUMN_ENDING_IN_PERIOD_TEST1.parquet">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -120,5 +109,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/ParquetViewer/App.config
+++ b/src/ParquetViewer/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-    </startup>
+  <startup>
+  </startup>
   <runtime>
   </runtime>
 </configuration>

--- a/src/ParquetViewer/App.config
+++ b/src/ParquetViewer/App.config
@@ -3,19 +3,5 @@
     <startup> 
     </startup>
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="IronSnappy" publicKeyToken="b1d4b1dc83bdcf31" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/ParquetViewer/Controls/ImagePreviewForm.Designer.cs
+++ b/src/ParquetViewer/Controls/ImagePreviewForm.Designer.cs
@@ -32,9 +32,8 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ImagePreviewForm));
             mainTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             saveAsPngButton = new System.Windows.Forms.Button();
-            mainPictureBox = new System.Windows.Forms.PictureBox();
-            copyToClipboardButton = new System.Windows.Forms.Button();
             closeButton = new System.Windows.Forms.Button();
+            mainPictureBox = new System.Windows.Forms.PictureBox();
             imageRightClickMenu = new System.Windows.Forms.ContextMenuStrip(components);
             copyToClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             mainTableLayoutPanel.SuspendLayout();
@@ -47,28 +46,40 @@
             mainTableLayoutPanel.ColumnCount = 2;
             mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            mainTableLayoutPanel.Controls.Add(saveAsPngButton, 1, 1);
+            mainTableLayoutPanel.Controls.Add(saveAsPngButton, 0, 1);
+            mainTableLayoutPanel.Controls.Add(closeButton, 1, 1);
             mainTableLayoutPanel.Controls.Add(mainPictureBox, 0, 0);
-            mainTableLayoutPanel.Controls.Add(copyToClipboardButton, 0, 1);
             mainTableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             mainTableLayoutPanel.Location = new System.Drawing.Point(0, 0);
             mainTableLayoutPanel.Name = "mainTableLayoutPanel";
             mainTableLayoutPanel.RowCount = 2;
             mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
-            mainTableLayoutPanel.Size = new System.Drawing.Size(246, 211);
+            mainTableLayoutPanel.Size = new System.Drawing.Size(539, 326);
             mainTableLayoutPanel.TabIndex = 0;
             // 
             // saveAsPngButton
             // 
             saveAsPngButton.Dock = System.Windows.Forms.DockStyle.Fill;
-            saveAsPngButton.Location = new System.Drawing.Point(126, 182);
+            saveAsPngButton.Location = new System.Drawing.Point(3, 297);
             saveAsPngButton.Name = "saveAsPngButton";
-            saveAsPngButton.Size = new System.Drawing.Size(117, 26);
-            saveAsPngButton.TabIndex = 2;
+            saveAsPngButton.Size = new System.Drawing.Size(263, 26);
+            saveAsPngButton.TabIndex = 3;
             saveAsPngButton.Text = "Save as PNG";
             saveAsPngButton.UseVisualStyleBackColor = true;
             saveAsPngButton.Click += saveAsPngButton_Click;
+            // 
+            // closeButton
+            // 
+            closeButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            closeButton.Location = new System.Drawing.Point(273, 297);
+            closeButton.Name = "closeButton";
+            closeButton.Size = new System.Drawing.Size(263, 26);
+            closeButton.TabIndex = 4;
+            closeButton.TabStop = false;
+            closeButton.Text = "Close";
+            closeButton.UseVisualStyleBackColor = true;
+            closeButton.Click += closeButton_Click;
             // 
             // mainPictureBox
             // 
@@ -77,45 +88,21 @@
             mainPictureBox.ContextMenuStrip = imageRightClickMenu;
             mainPictureBox.Location = new System.Drawing.Point(3, 3);
             mainPictureBox.Name = "mainPictureBox";
-            mainPictureBox.Size = new System.Drawing.Size(240, 173);
+            mainPictureBox.Size = new System.Drawing.Size(533, 288);
             mainPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             mainPictureBox.TabIndex = 0;
             mainPictureBox.TabStop = false;
-            // 
-            // copyToClipboardButton
-            // 
-            copyToClipboardButton.Dock = System.Windows.Forms.DockStyle.Fill;
-            copyToClipboardButton.Location = new System.Drawing.Point(3, 182);
-            copyToClipboardButton.Name = "copyToClipboardButton";
-            copyToClipboardButton.Size = new System.Drawing.Size(117, 26);
-            copyToClipboardButton.TabIndex = 1;
-            copyToClipboardButton.Text = "Copy to clipboard";
-            copyToClipboardButton.UseVisualStyleBackColor = true;
-            copyToClipboardButton.Click += copyToClipboardButton_Click;
-            // 
-            // closeButton
-            // 
-            closeButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
-            closeButton.Location = new System.Drawing.Point(94, 0);
-            closeButton.MaximumSize = new System.Drawing.Size(1, 1);
-            closeButton.Name = "closeButton";
-            closeButton.Size = new System.Drawing.Size(1, 0);
-            closeButton.TabIndex = 0;
-            closeButton.TabStop = false;
-            closeButton.Text = "Close";
-            closeButton.UseVisualStyleBackColor = true;
-            closeButton.Click += closeButton_Click;
             // 
             // imageRightClickMenu
             // 
             imageRightClickMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { copyToClipboardToolStripMenuItem });
             imageRightClickMenu.Name = "imageRightClickMenu";
-            imageRightClickMenu.Size = new System.Drawing.Size(181, 48);
+            imageRightClickMenu.Size = new System.Drawing.Size(170, 26);
             // 
             // copyToClipboardToolStripMenuItem
             // 
             copyToClipboardToolStripMenuItem.Name = "copyToClipboardToolStripMenuItem";
-            copyToClipboardToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            copyToClipboardToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
             copyToClipboardToolStripMenuItem.Text = "Copy to clipboard";
             copyToClipboardToolStripMenuItem.Click += copyToClipboardToolStripMenuItem_Click;
             // 
@@ -125,8 +112,7 @@
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             BackColor = System.Drawing.SystemColors.Control;
             CancelButton = closeButton;
-            ClientSize = new System.Drawing.Size(246, 211);
-            Controls.Add(closeButton);
+            ClientSize = new System.Drawing.Size(539, 326);
             Controls.Add(mainTableLayoutPanel);
             ForeColor = System.Drawing.Color.Black;
             Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
@@ -144,10 +130,9 @@
 
         private System.Windows.Forms.TableLayoutPanel mainTableLayoutPanel;
         private System.Windows.Forms.PictureBox mainPictureBox;
-        private System.Windows.Forms.Button saveAsPngButton;
-        private System.Windows.Forms.Button copyToClipboardButton;
         private System.Windows.Forms.Button closeButton;
         private System.Windows.Forms.ContextMenuStrip imageRightClickMenu;
         private System.Windows.Forms.ToolStripMenuItem copyToClipboardToolStripMenuItem;
+        private System.Windows.Forms.Button saveAsPngButton;
     }
 }

--- a/src/ParquetViewer/Controls/ImagePreviewForm.cs
+++ b/src/ParquetViewer/Controls/ImagePreviewForm.cs
@@ -59,26 +59,23 @@ namespace ParquetViewer.Controls
             }
         }
 
-        private async void copyToClipboardButton_Click(object sender, EventArgs e)
-        {
-            Clipboard.SetImage(this.mainPictureBox.Image);
-            if (sender is Button button)
-            {
-                string buttonText = button.Text;
-                button.Text = "Copied!";
-                button.Enabled = false;
-                await Task.Delay(2000);
-                button.Enabled = true;
-                button.Text = buttonText;
-            }
-        }
-
         private void closeButton_Click(object sender, EventArgs e)
         {
             this.Close();
         }
 
-        private void copyToClipboardToolStripMenuItem_Click(object sender, EventArgs e)
-            => copyToClipboardButton_Click(sender, e);
+        private async void copyToClipboardToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                this.mainPictureBox.Cursor = Cursors.WaitCursor;
+                Clipboard.SetImage(this.mainPictureBox.Image);
+                await Task.Delay(100);
+            }
+            finally
+            {
+                this.mainPictureBox.Cursor = Cursors.Default;
+            }
+        }
     }
 }

--- a/src/ParquetViewer/FieldSelectionDialog.Designer.cs
+++ b/src/ParquetViewer/FieldSelectionDialog.Designer.cs
@@ -30,12 +30,12 @@
         {
             mainTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             doneButton = new System.Windows.Forms.Button();
-            fieldsPanel = new System.Windows.Forms.Panel();
-            filterColumnsTextbox = new System.Windows.Forms.TextBox();
             clearfilterColumnsButton = new System.Windows.Forms.Button();
             showSelectedFieldsRadioButton = new System.Windows.Forms.RadioButton();
             allFieldsRadioButton = new System.Windows.Forms.RadioButton();
             rememberMyChoiceCheckBox = new System.Windows.Forms.CheckBox();
+            filterColumnsTextbox = new System.Windows.Forms.TextBox();
+            fieldsPanel = new System.Windows.Forms.Panel();
             mainTableLayoutPanel.SuspendLayout();
             SuspendLayout();
             // 
@@ -49,16 +49,17 @@
             mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 34F));
             mainTableLayoutPanel.Controls.Add(doneButton, 2, 5);
-            mainTableLayoutPanel.Controls.Add(fieldsPanel, 1, 3);
-            mainTableLayoutPanel.Controls.Add(filterColumnsTextbox, 1, 2);
             mainTableLayoutPanel.Controls.Add(clearfilterColumnsButton, 3, 2);
             mainTableLayoutPanel.Controls.Add(showSelectedFieldsRadioButton, 0, 1);
             mainTableLayoutPanel.Controls.Add(allFieldsRadioButton, 0, 0);
             mainTableLayoutPanel.Controls.Add(rememberMyChoiceCheckBox, 2, 0);
+            mainTableLayoutPanel.Controls.Add(filterColumnsTextbox, 0, 2);
+            mainTableLayoutPanel.Controls.Add(fieldsPanel, 1, 3);
             mainTableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             mainTableLayoutPanel.Location = new System.Drawing.Point(0, 0);
             mainTableLayoutPanel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             mainTableLayoutPanel.Name = "mainTableLayoutPanel";
+            mainTableLayoutPanel.Padding = new System.Windows.Forms.Padding(6, 0, 4, 0);
             mainTableLayoutPanel.RowCount = 6;
             mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
             mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
@@ -74,7 +75,7 @@
             // 
             doneButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
             mainTableLayoutPanel.SetColumnSpan(doneButton, 2);
-            doneButton.Location = new System.Drawing.Point(468, 381);
+            doneButton.Location = new System.Drawing.Point(464, 381);
             doneButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             doneButton.Name = "doneButton";
             doneButton.Size = new System.Drawing.Size(113, 29);
@@ -83,52 +84,26 @@
             doneButton.UseVisualStyleBackColor = true;
             doneButton.Click += doneButton_Click;
             // 
-            // fieldsPanel
-            // 
-            fieldsPanel.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            fieldsPanel.AutoScroll = true;
-            mainTableLayoutPanel.SetColumnSpan(fieldsPanel, 3);
-            fieldsPanel.Enabled = false;
-            fieldsPanel.Location = new System.Drawing.Point(27, 105);
-            fieldsPanel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            fieldsPanel.Name = "fieldsPanel";
-            mainTableLayoutPanel.SetRowSpan(fieldsPanel, 2);
-            fieldsPanel.Size = new System.Drawing.Size(554, 270);
-            fieldsPanel.TabIndex = 2;
-            // 
-            // filterColumnsTextbox
-            // 
-            filterColumnsTextbox.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            mainTableLayoutPanel.SetColumnSpan(filterColumnsTextbox, 2);
-            filterColumnsTextbox.Enabled = false;
-            filterColumnsTextbox.Location = new System.Drawing.Point(27, 74);
-            filterColumnsTextbox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            filterColumnsTextbox.Name = "filterColumnsTextbox";
-            filterColumnsTextbox.PlaceholderText = "search by name";
-            filterColumnsTextbox.Size = new System.Drawing.Size(520, 23);
-            filterColumnsTextbox.TabIndex = 0;
-            filterColumnsTextbox.TextChanged += filterColumnsTextbox_TextChanged;
-            // 
             // clearfilterColumnsButton
             // 
             clearfilterColumnsButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
             clearfilterColumnsButton.Enabled = false;
-            clearfilterColumnsButton.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            clearfilterColumnsButton.Location = new System.Drawing.Point(555, 73);
+            clearfilterColumnsButton.Font = new System.Drawing.Font("Segoe UI Semibold", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, 0);
+            clearfilterColumnsButton.Location = new System.Drawing.Point(551, 73);
             clearfilterColumnsButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             clearfilterColumnsButton.Name = "clearfilterColumnsButton";
             clearfilterColumnsButton.Size = new System.Drawing.Size(26, 26);
             clearfilterColumnsButton.TabIndex = 4;
             clearfilterColumnsButton.Text = "X";
-            clearfilterColumnsButton.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             clearfilterColumnsButton.UseVisualStyleBackColor = true;
+            clearfilterColumnsButton.Click += clearfilterColumnsButton_Click;
             // 
             // showSelectedFieldsRadioButton
             // 
             showSelectedFieldsRadioButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
             showSelectedFieldsRadioButton.AutoSize = true;
             mainTableLayoutPanel.SetColumnSpan(showSelectedFieldsRadioButton, 3);
-            showSelectedFieldsRadioButton.Location = new System.Drawing.Point(4, 38);
+            showSelectedFieldsRadioButton.Location = new System.Drawing.Point(10, 38);
             showSelectedFieldsRadioButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             showSelectedFieldsRadioButton.Name = "showSelectedFieldsRadioButton";
             showSelectedFieldsRadioButton.Size = new System.Drawing.Size(169, 29);
@@ -143,7 +118,7 @@
             allFieldsRadioButton.AutoSize = true;
             allFieldsRadioButton.Checked = true;
             mainTableLayoutPanel.SetColumnSpan(allFieldsRadioButton, 2);
-            allFieldsRadioButton.Location = new System.Drawing.Point(4, 8);
+            allFieldsRadioButton.Location = new System.Drawing.Point(10, 8);
             allFieldsRadioButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             allFieldsRadioButton.Name = "allFieldsRadioButton";
             allFieldsRadioButton.Size = new System.Drawing.Size(72, 19);
@@ -157,13 +132,40 @@
             // 
             rememberMyChoiceCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
             rememberMyChoiceCheckBox.AutoSize = true;
-            rememberMyChoiceCheckBox.Location = new System.Drawing.Point(86, 8);
+            rememberMyChoiceCheckBox.Location = new System.Drawing.Point(92, 8);
             rememberMyChoiceCheckBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 3);
             rememberMyChoiceCheckBox.Name = "rememberMyChoiceCheckBox";
             rememberMyChoiceCheckBox.Size = new System.Drawing.Size(144, 19);
             rememberMyChoiceCheckBox.TabIndex = 6;
             rememberMyChoiceCheckBox.Text = "Remember My Choice";
             rememberMyChoiceCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // filterColumnsTextbox
+            // 
+            filterColumnsTextbox.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            mainTableLayoutPanel.SetColumnSpan(filterColumnsTextbox, 3);
+            filterColumnsTextbox.Enabled = false;
+            filterColumnsTextbox.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            filterColumnsTextbox.Location = new System.Drawing.Point(10, 74);
+            filterColumnsTextbox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            filterColumnsTextbox.Name = "filterColumnsTextbox";
+            filterColumnsTextbox.PlaceholderText = "Search by name";
+            filterColumnsTextbox.Size = new System.Drawing.Size(533, 23);
+            filterColumnsTextbox.TabIndex = 0;
+            filterColumnsTextbox.TextChanged += filterColumnsTextbox_TextChanged;
+            // 
+            // fieldsPanel
+            // 
+            fieldsPanel.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            fieldsPanel.AutoScroll = true;
+            mainTableLayoutPanel.SetColumnSpan(fieldsPanel, 3);
+            fieldsPanel.Enabled = false;
+            fieldsPanel.Location = new System.Drawing.Point(33, 105);
+            fieldsPanel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            fieldsPanel.Name = "fieldsPanel";
+            mainTableLayoutPanel.SetRowSpan(fieldsPanel, 2);
+            fieldsPanel.Size = new System.Drawing.Size(544, 270);
+            fieldsPanel.TabIndex = 2;
             // 
             // FieldsToLoadForm
             // 

--- a/src/ParquetViewer/FieldSelectionDialog.cs
+++ b/src/ParquetViewer/FieldSelectionDialog.cs
@@ -255,9 +255,6 @@ namespace ParquetViewer
         {
             try
             {
-                //Clear filter text so all checked fields are loaded
-                clearfilterColumnsButton_Click(null, null);
-
                 if (this.rememberMyChoiceCheckBox.Enabled && this.rememberMyChoiceCheckBox.Checked)
                     AppSettings.AlwaysSelectAllFields = true;
                 else
@@ -268,19 +265,14 @@ namespace ParquetViewer
                 {
                     this.NewSelectedFields.AddRange(this.AvailableFields.Where(IsSupportedFieldType).Select(f => f.Name));
                 }
+                else if (this.PreSelectedFields.Count > 0)
+                {
+                    this.NewSelectedFields.AddRange(this.PreSelectedFields);
+                }
                 else
                 {
-                    foreach (Control control in this.fieldsPanel.Controls)
-                    {
-                        if (control is CheckBox checkbox && checkbox.Checked && !checkbox.Name.Equals(SelectAllCheckboxName) && checkbox.Enabled)
-                            this.NewSelectedFields.Add((string)control.Tag!);
-                    }
-
-                    if (this.NewSelectedFields.Count == 0)
-                    {
-                        MessageBox.Show("Please select at least 1 field", "Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                        return;
-                    }
+                    MessageBox.Show("Please select at least 1 field", "Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
                 }
 
                 this.DialogResult = DialogResult.OK;

--- a/src/ParquetViewer/Helpers/Constants.cs
+++ b/src/ParquetViewer/Helpers/Constants.cs
@@ -32,7 +32,8 @@ namespace ParquetViewer.Helpers
     public enum FileType
     {
         CSV = 0,
-        XLS
+        XLS,
+        JSON
     }
 
     public enum AutoSizeColumnsMode

--- a/src/ParquetViewer/Helpers/Constants.cs
+++ b/src/ParquetViewer/Helpers/Constants.cs
@@ -33,7 +33,8 @@ namespace ParquetViewer.Helpers
     {
         CSV = 0,
         XLS,
-        JSON
+        JSON,
+        PARQUET
     }
 
     public enum AutoSizeColumnsMode

--- a/src/ParquetViewer/Helpers/ExtensionMethods.cs
+++ b/src/ParquetViewer/Helpers/ExtensionMethods.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Win32;
+using Parquet.Schema;
 using ParquetViewer.Engine.Types;
 using System;
 using System.Collections.Generic;
@@ -58,6 +59,7 @@ namespace ParquetViewer.Helpers
         {
             FileType.CSV => ".csv",
             FileType.XLS => ".xls",
+            FileType.JSON => ".json",
             _ => throw new ArgumentOutOfRangeException(nameof(fileType))
         };
 
@@ -110,13 +112,13 @@ namespace ParquetViewer.Helpers
         /// Returns true if the type is a "simple" type. Basically anything that isn't a class or array.
         /// </summary>
         /// <remarks>Source: https://stackoverflow.com/a/65079923/1458738</remarks>
-        public static bool IsSimple(this Type type) 
+        public static bool IsSimple(this Type type)
             => TypeDescriptor.GetConverter(type).CanConvertFrom(typeof(string));
 
         /// <summary>
         /// Returns true if the type is a number type.
         /// </summary>
-        public static bool IsNumber(this Type type) => 
+        public static bool IsNumber(this Type type) =>
             Array.Exists(type.GetInterfaces(), i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(INumber<>));
 
         public static T ToEnum<T>(this int value) where T : struct, Enum

--- a/src/ParquetViewer/Helpers/UtilityMethods.cs
+++ b/src/ParquetViewer/Helpers/UtilityMethods.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 
 namespace ParquetViewer.Helpers
 {
@@ -29,7 +28,7 @@ namespace ParquetViewer.Helpers
         }
 
         /// <summary>
-        /// Returns a <see cref="FileType"/> if a matching one if found for a given file extension.
+        /// Returns a <see cref="FileType"/> if a matching one is found for a given file extension.
         /// </summary>
         /// <param name="extension">File extension in ".xyz" format</param>
         /// <returns>null if no matching file type is found</returns>

--- a/src/ParquetViewer/Helpers/UtilityMethods.cs
+++ b/src/ParquetViewer/Helpers/UtilityMethods.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Data;
-using System.Linq;
-using System.Threading;
+﻿using System;
+using System.IO;
 
 namespace ParquetViewer.Helpers
 {
@@ -14,9 +12,15 @@ namespace ParquetViewer.Helpers
                 //In RFC 4180 we escape quotes with double quotes
                 string formattedValue = value.Replace("\"", "\"\"");
 
-                //Enclose value with quotes if it contains commas,line feeds or other quotes
-                if (formattedValue.Contains(",") || formattedValue.Contains("\r") || formattedValue.Contains("\n") || formattedValue.Contains("\"\"") || alwaysEncloseInQuotes)
-                    formattedValue = string.Concat("\"", formattedValue, "\"");
+                //Enclose value with quotes if it contains commas, line feeds, or other quotes
+                foreach (char c in formattedValue)
+                {
+                    if (c == ',' || c == '\r' || c == '\n' || c == '\"' || alwaysEncloseInQuotes)
+                    {
+                        formattedValue = string.Concat("\"", formattedValue, "\"");
+                        break;
+                    }
+                }                    
 
                 return formattedValue;
             }
@@ -24,34 +28,19 @@ namespace ParquetViewer.Helpers
                 return string.Empty;
         }
 
-        public static IEnumerable<IList<T>> Split<T>(ICollection<T> src, int splitIntoPieces)
+        /// <summary>
+        /// Returns a <see cref="FileType"/> if a matching one if found for a given file extension.
+        /// </summary>
+        /// <param name="extension">File extension in ".xyz" format</param>
+        /// <returns>null if no matching file type is found</returns>
+        public static FileType? ExtensionToFileType(string extension)
         {
-            int maxItems = src.Count / splitIntoPieces;
-            int remainder = src.Count % splitIntoPieces;
-            bool pieceDone = false;
-
-            var list = new List<T>();
-            foreach (var t in src)
+            foreach (FileType fileType in Enum.GetValues(typeof(FileType)))
             {
-                list.Add(t);
-
-                if (remainder > 0 && !pieceDone)
-                {
-                    remainder--;
-                    pieceDone = true;
-                    continue;
-                }
-
-                if (list.Count == maxItems || pieceDone)
-                {
-                    pieceDone = false;
-                    yield return list;
-                    list = new List<T>();
-                }
+                if (fileType.GetExtension().Equals(extension))
+                    return fileType;
             }
-
-            if (list.Count > 0)
-                yield return list;
+            return null;
         }
     }
 }

--- a/src/ParquetViewer/MainForm.Designer.cs
+++ b/src/ParquetViewer/MainForm.Designer.cs
@@ -33,7 +33,7 @@ namespace ParquetViewer
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            DataGridViewCellStyle dataGridViewCellStyle3 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle2 = new DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             mainTableLayoutPanel = new TableLayoutPanel();
             recordsToLabel = new Label();
@@ -102,9 +102,9 @@ namespace ParquetViewer
             mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
             mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 117F));
             mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 93F));
-            mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 54F));
+            mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 55F));
             mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 70F));
-            mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 54F));
+            mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 55F));
             mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 70F));
             mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
             mainTableLayoutPanel.Controls.Add(recordsToLabel, 8, 0);
@@ -156,7 +156,7 @@ namespace ParquetViewer
             // showRecordsFromLabel
             // 
             showRecordsFromLabel.Anchor = AnchorStyles.Right;
-            showRecordsFromLabel.Location = new System.Drawing.Point(681, 0);
+            showRecordsFromLabel.Location = new System.Drawing.Point(680, 0);
             showRecordsFromLabel.Margin = new Padding(0, 0, 4, 0);
             showRecordsFromLabel.Name = "showRecordsFromLabel";
             showRecordsFromLabel.Size = new System.Drawing.Size(45, 35);
@@ -168,7 +168,7 @@ namespace ParquetViewer
             // 
             offsetTextBox.Anchor = AnchorStyles.Left | AnchorStyles.Right;
             offsetTextBox.DelayedTextChangedTimeout = 1000;
-            offsetTextBox.Location = new System.Drawing.Point(734, 6);
+            offsetTextBox.Location = new System.Drawing.Point(733, 6);
             offsetTextBox.Margin = new Padding(4, 3, 4, 3);
             offsetTextBox.Name = "offsetTextBox";
             offsetTextBox.Size = new System.Drawing.Size(62, 23);
@@ -185,7 +185,7 @@ namespace ParquetViewer
             runQueryButton.ForeColor = System.Drawing.Color.DarkRed;
             runQueryButton.Image = Properties.Resources.exclamation_icon;
             runQueryButton.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            runQueryButton.Location = new System.Drawing.Point(470, 3);
+            runQueryButton.Location = new System.Drawing.Point(468, 3);
             runQueryButton.Margin = new Padding(4, 3, 4, 3);
             runQueryButton.Name = "runQueryButton";
             runQueryButton.Size = new System.Drawing.Size(109, 29);
@@ -220,7 +220,7 @@ namespace ParquetViewer
             searchFilterTextBox.Margin = new Padding(4, 3, 4, 3);
             searchFilterTextBox.Name = "searchFilterTextBox";
             searchFilterTextBox.PlaceholderText = "WHERE ";
-            searchFilterTextBox.Size = new System.Drawing.Size(353, 23);
+            searchFilterTextBox.Size = new System.Drawing.Size(351, 23);
             searchFilterTextBox.TabIndex = 1;
             searchFilterTextBox.Enter += searchFilterTextBox_Enter;
             searchFilterTextBox.KeyPress += searchFilterTextBox_KeyPress;
@@ -232,7 +232,7 @@ namespace ParquetViewer
             clearFilterButton.FlatStyle = FlatStyle.Popup;
             clearFilterButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F);
             clearFilterButton.ForeColor = System.Drawing.Color.Black;
-            clearFilterButton.Location = new System.Drawing.Point(587, 3);
+            clearFilterButton.Location = new System.Drawing.Point(585, 3);
             clearFilterButton.Margin = new Padding(4, 3, 4, 3);
             clearFilterButton.Name = "clearFilterButton";
             clearFilterButton.Size = new System.Drawing.Size(85, 29);
@@ -249,14 +249,14 @@ namespace ParquetViewer
             mainGridView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             mainGridView.ClipboardCopyMode = DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
             mainGridView.ColumnHeadersBorderStyle = DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle3.Alignment = DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Segoe UI Semibold", 9F, System.Drawing.FontStyle.Bold);
-            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle3.WrapMode = DataGridViewTriState.True;
-            mainGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle2.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Segoe UI Semibold", 9F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle2.WrapMode = DataGridViewTriState.True;
+            mainGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
             mainGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             mainTableLayoutPanel.SetColumnSpan(mainGridView, 11);
             mainGridView.EnableHeadersVisualStyles = false;
@@ -517,14 +517,14 @@ namespace ParquetViewer
             // 
             userGuideToolStripMenuItem.Image = Properties.Resources.external_link_icon;
             userGuideToolStripMenuItem.Name = "userGuideToolStripMenuItem";
-            userGuideToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            userGuideToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
             userGuideToolStripMenuItem.Text = "User Guide";
             userGuideToolStripMenuItem.Click += userGuideToolStripMenuItem_Click;
             // 
             // shareAnonymousUsageDataToolStripMenuItem
             // 
             shareAnonymousUsageDataToolStripMenuItem.Name = "shareAnonymousUsageDataToolStripMenuItem";
-            shareAnonymousUsageDataToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            shareAnonymousUsageDataToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
             shareAnonymousUsageDataToolStripMenuItem.Text = "Share Usage Data";
             shareAnonymousUsageDataToolStripMenuItem.ToolTipText = "See About page for link to privacy policy";
             shareAnonymousUsageDataToolStripMenuItem.Click += shareAnonymousUsageDataToolStripMenuItem_Click;
@@ -532,7 +532,7 @@ namespace ParquetViewer
             // aboutToolStripMenuItem
             // 
             aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            aboutToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
             aboutToolStripMenuItem.Text = "&About...";
             aboutToolStripMenuItem.Click += aboutToolStripMenuItem_Click;
             // 

--- a/src/ParquetViewer/MainForm.EventHandlers.cs
+++ b/src/ParquetViewer/MainForm.EventHandlers.cs
@@ -84,13 +84,12 @@ namespace ParquetViewer
 
         private void searchFilterLabel_Click(object sender, EventArgs e)
         {
-            MessageBox.Show(@"Detailed documentation : https://github.com/mukunku/ParquetViewer/wiki/Running-Queries
-NULL CHECK: 
+            MessageBox.Show(@"NULL CHECK: 
     WHERE field_name IS NULL
     WHERE field_name IS NOT NULL
 DATETIME:   
     WHERE field_name >= #2000/12/31#
-    WHERE field_name >= #12/31/2000#
+    WHERE field_name = #12/31/2000#
 NUMERIC:
     WHERE field_name <= 123.4
 STRING:
@@ -98,7 +97,9 @@ STRING:
     WHERE field_name = 'equals value'
     WHERE field_name <> 'not equals'
 MULTIPLE CONDITIONS: 
-    WHERE (field_1 > #2000/12/31# AND field_1 < #2001/12/31#) OR field_2 <> 100 OR field_3 = 'string value'", "Filtering Query Syntax Examples");
+    WHERE (field_1 > #2000/12/31# AND field_1 < #2001/12/31#) OR field_2 * 5 > 100 OR field_3 <> 'string value'
+
+Checkout 'Help → User Guide' for more information.", "Filtering Query Syntax Examples");
         }
 
         private void mainGridView_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)

--- a/src/ParquetViewer/MainForm.EventHandlers.cs
+++ b/src/ParquetViewer/MainForm.EventHandlers.cs
@@ -92,12 +92,13 @@ DATETIME:
     WHERE field_name = #12/31/2000#
 NUMERIC:
     WHERE field_name <= 123.4
+    WHERE (field1 * field2) / 100 > 0.1
 STRING:
     WHERE field_name LIKE '%value%' 
     WHERE field_name = 'equals value'
     WHERE field_name <> 'not equals'
 MULTIPLE CONDITIONS: 
-    WHERE (field_1 > #2000/12/31# AND field_1 < #2001/12/31#) OR field_2 * 5 > 100 OR field_3 <> 'string value'
+    WHERE (field_1 > #2000/12/31# AND field_1 < #2001/12/31#) OR field_2 <> 100
 
 Checkout 'Help → User Guide' for more information.", "Filtering Query Syntax Examples");
         }

--- a/src/ParquetViewer/MainForm.Helpers.cs
+++ b/src/ParquetViewer/MainForm.Helpers.cs
@@ -298,7 +298,7 @@ namespace ParquetViewer
         private static void HandleFileReadException(FileReadException ex)
         {
             ShowError($"Could not load parquet file.{Environment.NewLine}{Environment.NewLine}" +
-                $"If the problem persists please consider opening a bug ticket in the project repo: Help -> About{Environment.NewLine}{Environment.NewLine}" +
+                $"If the problem persists please consider opening a bug ticket in the project repo: Help → About{Environment.NewLine}{Environment.NewLine}" +
                 $"{ex}");
         }
 

--- a/src/ParquetViewer/MainForm.Helpers.cs
+++ b/src/ParquetViewer/MainForm.Helpers.cs
@@ -235,6 +235,31 @@ namespace ParquetViewer
             excelWriter.EndWrite();
         }
 
+        private void WriteDataToJSONFile(string path, CancellationToken cancellationToken)
+        {
+            using var fs = new FileStream(path, FileMode.OpenOrCreate);
+            using var jsonWriter = new Utf8JsonWriter(fs);
+            
+            jsonWriter.WriteStartArray();
+            foreach (DataRowView row in this.MainDataSource.DefaultView)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                for (var i = 0; i < row.Row.ItemArray.Count; i++)
+                {
+                    var columnName = this.MainDataSource.Columns[i].Name;
+                    jsonWriter.WritePropertyName(columnName);
+
+                    object? value = row.Row.ItemArray[i];
+                    StructValue.WriteValue(jsonWriter, value!, false);
+                }
+            }
+            jsonWriter.WriteEndArray();
+        }
+
         private static void HandleAllFilesSkippedException(AllFilesSkippedException ex)
         {
             var sb = new StringBuilder();

--- a/src/ParquetViewer/MainForm.Helpers.cs
+++ b/src/ParquetViewer/MainForm.Helpers.cs
@@ -50,7 +50,7 @@ namespace ParquetViewer
                     if (this.exportFileDialog.ShowDialog() == DialogResult.OK)
                     {
                         filePath = this.exportFileDialog.FileName;
-                        File.Delete(filePath); //Delete any existing file (user already confirmed any overwrite)
+                        CleanupFile(filePath); //Delete any existing file (user already confirmed any overwrite)
 
                         var fileExtension = Path.GetExtension(filePath);
                         FileType? selectedFileType = UtilityMethods.ExtensionToFileType(fileExtension);

--- a/src/ParquetViewer/MainForm.Helpers.cs
+++ b/src/ParquetViewer/MainForm.Helpers.cs
@@ -91,9 +91,10 @@ namespace ParquetViewer
                         }
                         else
                         {
-                            FileExportEvent.FireAndForget(selectedFileType.Value, new FileInfo(filePath).Length, 
+                            long fileSizeInBytes = new FileInfo(filePath).Length;
+                            FileExportEvent.FireAndForget(selectedFileType.Value, fileSizeInBytes, 
                                 this.mainGridView.RowCount, this.mainGridView.ColumnCount, stopWatch.ElapsedMilliseconds);
-                            MessageBox.Show("Export successful!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                            MessageBox.Show($"Export successful!{Environment.NewLine}{Environment.NewLine}File size: { Math.Round((fileSizeInBytes / 1024.0) / 1024.0, 2) } MB", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
                         }
                     }
                 }

--- a/src/ParquetViewer/MainForm.Helpers.cs
+++ b/src/ParquetViewer/MainForm.Helpers.cs
@@ -353,6 +353,11 @@ namespace ParquetViewer
                 $"{ex}");
         }
 
+        private static void HandleFileNotFoundException(FileNotFoundException ex)
+        {
+            ShowError(ex.Message);
+        }
+
         private static void HandleMultipleSchemasFoundException(MultipleSchemasFoundException ex)
         {
             var sb = new StringBuilder();

--- a/src/ParquetViewer/MainForm.Helpers.cs
+++ b/src/ParquetViewer/MainForm.Helpers.cs
@@ -50,6 +50,8 @@ namespace ParquetViewer
                     if (this.exportFileDialog.ShowDialog() == DialogResult.OK)
                     {
                         filePath = this.exportFileDialog.FileName;
+                        File.Delete(filePath); //Delete any existing file (user already confirmed any overwrite)
+
                         var fileExtension = Path.GetExtension(filePath);
                         FileType? selectedFileType = UtilityMethods.ExtensionToFileType(fileExtension);
 
@@ -250,7 +252,7 @@ namespace ParquetViewer
             using var jsonWriter = new Utf8JsonWriter(fs);
             
             jsonWriter.WriteStartArray();
-            foreach (DataRowView row in this.MainDataSource.DefaultView)
+            foreach (DataRowView row in this.MainDataSource!.DefaultView)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {

--- a/src/ParquetViewer/MainForm.Helpers.cs
+++ b/src/ParquetViewer/MainForm.Helpers.cs
@@ -304,7 +304,7 @@ namespace ParquetViewer
 {
     ""CreatedBy"": ""ParquetViewer"",
     ""Website"": ""https://github.com/mukunku/ParquetViewer"",
-    ""CreationDate"": """ + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + @"""
+    ""CreationDate"": """ + DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss") + @"""
 }
 " }
             };

--- a/src/ParquetViewer/MainForm.cs
+++ b/src/ParquetViewer/MainForm.cs
@@ -226,6 +226,10 @@ namespace ParquetViewer
                     {
                         HandleMultipleSchemasFoundException(msfe);
                     }
+                    else if (ex is FileNotFoundException fnfe)
+                    {
+                        HandleFileNotFoundException(fnfe);
+                    }
                     else if (ex is not OperationCanceledException)
                     {
                         throw;
@@ -385,8 +389,9 @@ namespace ParquetViewer
             this.searchFilterTextBox.PlaceholderText = "WHERE ";
 
             var fieldList = await this.OpenFieldSelectionDialog(false);
+            var wasOpenSuccess = this._openParquetEngine is not null;
 
-            if (AppSettings.AlwaysLoadAllRecords)
+            if (wasOpenSuccess && AppSettings.AlwaysLoadAllRecords)
             {
                 this.currentMaxRowCount = (int)this._openParquetEngine!.RecordCount;
                 this.recordCountTextBox.SetTextQuiet(this._openParquetEngine.RecordCount.ToString());

--- a/src/ParquetViewer/MainForm.resx
+++ b/src/ParquetViewer/MainForm.resx
@@ -127,24 +127,6 @@
     <value>382, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="getSQLCreateTableScriptToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAArpJREFUWEftV01rE1EUjUOsKVTaleCiP8CmUvqR76RJC2aRIKSLIBbETW0tBGJa
-        22CkaJddBqoli4JIpLsIUoylaBf9ABFNM5LGjywFF+LCHzC5nffyXvpm8maSJkVd5MCBmXvvnHPmTmYg
-        hv8e5deGC/DKAPBG5paKch31yagmeh72wPrButcUN0HXcpfXGDVCYC0AqE5GlJC2L/+ummQN8Gv3Lhzl
-        3oGYz0FeLGAWcnvw4+AR7tNZaVN4TySaBzXNi59BFMWGieZpGCKli1gm5uVuAAnwDBplowE0gQR+7ie4
-        4vX4ZydwNhuglLIm+PoxA4fiEdfwUPwCpQ/PobwlVK9BJFLNgRVqiOi57/UDlB5Xa0RKFw1tQJel5Yop
-        S9IjUs1BYaLHdoB2gHYAOYBUjG9MT0c2fD4/NoXtS7iHhTTg9wf1A9YYaZFsQCreK1itbnC7x8DjGQfp
-        0823RKoGaAZxYMCiHYJrpiKeYx/B9wSYzYNY3Gbz1IinUqnz1JxyeNjBD8EzVJOMyiEqAcrfHnhZcdLG
-        SKfTV9keotPp5Zsj8AzVRHOsUSQSnaHiLteJeDy+dJ3WKdHjIm0+eIZqlnf7J9TCLGOx+xNIa2jIrqij
-        c2yih3Jx4SLPVE00y4pTzs5Gr4TDN56g3wJbt9nq3DkPsMk3p5R2zCkyiuF2j8Pq6toL1thqdZ3euFXY
-        7Sd3T0p/DyMjDrDbR+VNPL01OXkbB+jrG9QP0jHXcSZJ0evl813DWuh4amrmDt2ExeLU9gg/C7ccwOMZ
-        g1BIqUPNKdF2SEuJzsXOlgK4XD75Dl375FQBdQiHg/MRMs4bmw6ARIPBkO71tSFGlfPzL+ey5PBUQGJO
-        p6+h8GhLbAhSrqA70Y0LwqIAK9kVj7AgQCKTgN6lXk1x9FVLJpN1/5iyYMzPVSr/HAbDMUiXlYfiKZ6T
-        AAAAAElFTkSuQmCC
-</value>
-  </data>
   <data name="newToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -245,6 +227,24 @@
         gvfnz1cn5Y9HRvz1/iruPuAkvouloL63Crz7F3WpLFpZiyDKMnfRK9X3VkGUZaKSlbUIoixjlZgqrBJT
         hVViqnCDyawBXQNulSWjWdcA3BiZwg0mc6wBuDEyRVRmZAo3mMyxBuDGyBRRmZEp3GAya8DPAXv4EE2s
         MsPFRkovkH56TwbQBuIAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="getSQLCreateTableScriptToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAArpJREFUWEftV01rE1EUjUOsKVTaleCiP8CmUvqR76RJC2aRIKSLIBbETW0tBGJa
+        22CkaJddBqoli4JIpLsIUoylaBf9ABFNM5LGjywFF+LCHzC5nffyXvpm8maSJkVd5MCBmXvvnHPmTmYg
+        hv8e5deGC/DKAPBG5paKch31yagmeh72wPrButcUN0HXcpfXGDVCYC0AqE5GlJC2L/+ummQN8Gv3Lhzl
+        3oGYz0FeLGAWcnvw4+AR7tNZaVN4TySaBzXNi59BFMWGieZpGCKli1gm5uVuAAnwDBplowE0gQR+7ie4
+        4vX4ZydwNhuglLIm+PoxA4fiEdfwUPwCpQ/PobwlVK9BJFLNgRVqiOi57/UDlB5Xa0RKFw1tQJel5Yop
+        S9IjUs1BYaLHdoB2gHYAOYBUjG9MT0c2fD4/NoXtS7iHhTTg9wf1A9YYaZFsQCreK1itbnC7x8DjGQfp
+        0823RKoGaAZxYMCiHYJrpiKeYx/B9wSYzYNY3Gbz1IinUqnz1JxyeNjBD8EzVJOMyiEqAcrfHnhZcdLG
+        SKfTV9keotPp5Zsj8AzVRHOsUSQSnaHiLteJeDy+dJ3WKdHjIm0+eIZqlnf7J9TCLGOx+xNIa2jIrqij
+        c2yih3Jx4SLPVE00y4pTzs5Gr4TDN56g3wJbt9nq3DkPsMk3p5R2zCkyiuF2j8Pq6toL1thqdZ3euFXY
+        7Sd3T0p/DyMjDrDbR+VNPL01OXkbB+jrG9QP0jHXcSZJ0evl813DWuh4amrmDt2ExeLU9gg/C7ccwOMZ
+        g1BIqUPNKdF2SEuJzsXOlgK4XD75Dl375FQBdQiHg/MRMs4bmw6ARIPBkO71tSFGlfPzL+ey5PBUQGJO
+        p6+h8GhLbAhSrqA70Y0LwqIAK9kVj7AgQCKTgN6lXk1x9FVLJpN1/5iyYMzPVSr/HAbDMUiXlYfiKZ6T
+        AAAAAElFTkSuQmCC
 </value>
   </data>
   <metadata name="mainStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/ParquetViewer/ParquetViewer.csproj
+++ b/src/ParquetViewer/ParquetViewer.csproj
@@ -5,12 +5,10 @@
     <AssemblyName>ParquetViewer</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-	<SelfContained>false</SelfContained>
-	<PublishSingleFile>true</PublishSingleFile>
-	<PublishReadyToRun>false</PublishReadyToRun>
-	<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-	<Configurations>Debug;Release;Release_SelfContained</Configurations>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <Configurations>Debug;Release;Release_SelfContained</Configurations>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\parquet_icon.ico</ApplicationIcon>

--- a/src/ParquetViewer/Program.cs
+++ b/src/ParquetViewer/Program.cs
@@ -148,7 +148,7 @@ namespace ParquetViewer
             {
                 if (MessageBox.Show($"Would you like to associate ParquetViewer with .parquet files?{Environment.NewLine}{Environment.NewLine}" +
                         $"Executable path: {System.Windows.Forms.Application.ExecutablePath}{Environment.NewLine}{Environment.NewLine}" +
-                        $"You can also toggle this setting from the Help -> About page.", 
+                        $"You can also toggle this setting from the Help → About page.", 
                         "ParquetViewer file association request", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {
                     if (!User.IsAdministrator)
@@ -156,13 +156,13 @@ namespace ParquetViewer
                         bool? success = AboutBox.RunElevatedExeForFileAssociation(true, out int? exitCode);
                         if (success is null)
                         {
-                            MessageBox.Show("File association cancelled. If you change your mind and would like to change .parquet file association visit the Help -> About page.",
+                            MessageBox.Show("File association cancelled. If you change your mind and would like to change .parquet file association visit the Help → About page.",
                                 "File association cancelled", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                         }
                         else if (success == false)
                         {
                             MessageBox.Show($"Something went wrong (Error code: {exitCode}).{Environment.NewLine}{Environment.NewLine}" +
-                                $"You can try again from the Help -> About page.",
+                                $"You can try again from the Help → About page.",
                                 "File association failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                         else
@@ -182,7 +182,7 @@ namespace ParquetViewer
                         catch (Exception ex)
                         {
                             MessageBox.Show($"Something went wrong (Error message: {ex.Message}).{Environment.NewLine}{Environment.NewLine}" +
-                                $"You can try again from the Help -> About page.",
+                                $"You can try again from the Help → About page.",
                                 "File association failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     }

--- a/src/ParquetViewer/Properties/AssemblyInfo.cs
+++ b/src/ParquetViewer/Properties/AssemblyInfo.cs
@@ -36,4 +36,4 @@ using System.Runtime.Versioning;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.0.1")]
+[assembly: AssemblyVersion("3.1.0.0")]


### PR DESCRIPTION
This PR:
* Adds the ability to `Save Results As` both `.json` and `.parquet`
   * Complex types (list, map, struct) are not supported for export as `.parquet` just yet.
* UI Tweaks here and there
* Updates dependency libraries
*  I'm going to set `PublishReadyToRun` to true when publishing Self Contained executables. 
   * Trying to see if [this flag](https://learn.microsoft.com/en-us/dotnet/core/deploying/ready-to-run) will help speed up launch times of the Self Contained ParquetViewer.
   * The self contained executable's file size is going to increase by ~10MB.
* [Fixes a NRE](https://github.com/mukunku/ParquetViewer/pull/113/commits/a47d1ad5b8dbe2eba9f11578415e9bb459170b40) that can happen if you have the flag to always load all records and the file open operation fails.