### PR TITLE
Add Simplified Chinese (zh-CN) and Traditional Chinese (zh-TW) locali…

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -1,7 +1,9 @@
 name: Test and Publish
 
 on:
- pull_request:
+  push:
+    branches: [ main, add-chinese-localization ]
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -50,6 +50,15 @@ jobs:
         comment-title: 'Unit Test Results'
         results-path: ./src/ParquetViewer.Tests/TestResults/*.trx
 
+    - name: Publish executable
+      run: dotnet publish src/ParquetViewer/ParquetViewer.csproj -c Debug -f net10.0-windows --nologo -o publish -r win-x64 --no-self-contained
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: ParquetViewer
+        path: publish/ParquetViewer.exe
+
   checkPublish:
     runs-on: windows-latest
     needs: test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# ParquetViewer — Agent Guide
+
+## Project structure
+
+Solution at `src/ParquetViewer.sln` (5 projects):
+
+| Project | Target | Role |
+|---------|--------|------|
+| `ParquetViewer` | `net10.0-windows` | WinForms app, entrypoint `Program.cs` → `MainForm` |
+| `ParquetViewer.Engine` | `net10.0` | Interfaces: `IParquetEngine`, `IParquetMetadata`, schema types |
+| `ParquetViewer.Engine.ParquetNET` | `net10.0` | Parquet.Net engine (always included) |
+| `ParquetViewer.Engine.DuckDB` | `net10.0` | DuckDB engine (only in `Release_SelfContained` builds) |
+| `ParquetViewer.Tests` | `net10.0-windows` | MSTest tests |
+
+All NuGet versions pinned centrally in `src/Directory.Packages.props`.
+
+## Build & test
+
+```powershell
+dotnet restore src/ParquetViewer.sln
+dotnet build src/ParquetViewer.sln --configuration Debug
+dotnet test src/ParquetViewer.sln --no-build --logger trx
+```
+
+- CI uses `dotnet-version: 8.0.x` (runner image may bundle newer SDK; adjust if build fails)
+- `EnforceCodeStyleInBuild` = true — editorconfig violations are build errors
+- Three configurations: `Debug`, `Release`, `Release_SelfContained`
+
+## Code style (editorconfig — enforced at build)
+
+- **No `var`** — explicit types required everywhere (`csharp_style_var_* = false`)
+- Allman braces (`csharp_new_line_before_open_brace = all`)
+- CRLF line endings, 4-space indent
+- Interface prefix `I`, PascalCase for types/methods/properties/events
+- No qualification with `this.` for fields/properties/methods/events
+- Prefer primary constructors, pattern matching, switch expressions
+
+## Engine architecture
+
+`IParquetEngine` abstraction with two implementations:
+- `ParquetNET` — used in Debug & Release; Parquet.Net library
+- `DuckDB` — **only** referenced in `Release_SelfContained` (saves ~30 MB); DuckDB.NET.Data.Full
+
+The `ParquetViewer` project conditionally includes DuckDB:
+```xml
+<ItemGroup Condition="'$(Configuration)' == 'Release_SelfContained'">
+  <ProjectReference Include="..\ParquetViewer.Engine.DuckDB\..." />
+</ItemGroup>
+```
+
+Tests test both engines (abstract `EngineTests` base → `ParquetNETEngineTests` + `DuckDBEngineTests`).
+
+## Testing quirks (MSTest v4)
+
+- **Framework:** MSTest (`Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter`, `MSTest.TestFramework`)
+- Custom `SkippableTestMethod` + `SkipWhenAttribute` for conditional test skipping per engine
+- Methods run in parallel by default (`[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]`)
+- Test fixtures: 31 `.parquet` files in `src/ParquetViewer.Tests/Data/` (copied to output dir on build)
+- `RichardSzalay.MockHttp` for HTTP mocking (analytics tests)
+- Test report: `src/ParquetViewer.Tests/TestResults/*.trx`
+
+## Localization
+
+- Resources in `src/ParquetViewer/Resources/` (`Strings.resx`, `Errors.resx`, `Icons.resx`)
+- Turkish translations via `.tr.resx` suffix files
+- Generated designers checked in; edit the `.resx` XML, regenerate with ResXFileCodeGenerator
+
+## Settings & analytics
+
+- Settings stored in Windows Registry: `HKCU\ParquetViewer`
+- Analytics via Amplitude (opt-in, prompted on 2nd+ launch 24h apart)
+- API key injected at CI build time via `AMPLITUDE_API_KEY` secret into `Analytics/AmplitudeEvent.cs`
+
+## Notable flows in Program.cs
+
+- **File association mode:** first arg `AboutBox.PERFORM_FILE_ASSOCIATION` → register .parquet handler
+- **Dark mode:** automatically offered after 30/300 opens if system is in dark mode
+- **First-arg as path:** if `args[0]` is a valid file/directory, `MainForm(pathToOpen)` opens it

--- a/src/ParquetViewer/AboutBox.zh-CN.resx
+++ b/src/ParquetViewer/AboutBox.zh-CN.resx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="labelProductName.Text" xml:space="preserve">
+    <value>产品名称</value>
+  </data>
+  <data name="labelCopyright.Text" xml:space="preserve">
+    <value>版权</value>
+  </data>
+  <data name="labelCompanyName.Text" xml:space="preserve">
+    <value>作者：Mukunku</value>
+  </data>
+  <data name="associateFileExtensionCheckBox.Text" xml:space="preserve">
+    <value>关联 .parquet 文件</value>
+  </data>
+  <data name="labelVersion.Text" xml:space="preserve">
+    <value>版本 {0}{1}</value>
+  </data>
+  <data name="newVersionLabel.Text" xml:space="preserve">
+    <value>（最新：{0}）</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>关于 {0}</value>
+  </data>
+</root>

--- a/src/ParquetViewer/AboutBox.zh-TW.resx
+++ b/src/ParquetViewer/AboutBox.zh-TW.resx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="labelProductName.Text" xml:space="preserve">
+    <value>產品名稱</value>
+  </data>
+  <data name="labelCopyright.Text" xml:space="preserve">
+    <value>著作權</value>
+  </data>
+  <data name="labelCompanyName.Text" xml:space="preserve">
+    <value>作者：Mukunku</value>
+  </data>
+  <data name="associateFileExtensionCheckBox.Text" xml:space="preserve">
+    <value>關聯 .parquet 檔案</value>
+  </data>
+  <data name="labelVersion.Text" xml:space="preserve">
+    <value>版本 {0}{1}</value>
+  </data>
+  <data name="newVersionLabel.Text" xml:space="preserve">
+    <value>（最新：{0}）</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>關於 {0}</value>
+  </data>
+</root>

--- a/src/ParquetViewer/Controls/QuickPeekForm.zh-CN.resx
+++ b/src/ParquetViewer/Controls/QuickPeekForm.zh-CN.resx
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="takeMeBackLinkLabel.Text" xml:space="preserve">
+    <value>&lt;&lt;&lt; 返回</value>
+  </data>
+  <data name="saveImageToFileButton.Text" xml:space="preserve">
+    <value>另存为 PNG</value>
+  </data>
+  <data name="copyToClipboardToolStripMenuItem.Text" xml:space="preserve">
+    <value>复制到剪贴板</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>快速预览</value>
+  </data>
+</root>

--- a/src/ParquetViewer/Controls/QuickPeekForm.zh-TW.resx
+++ b/src/ParquetViewer/Controls/QuickPeekForm.zh-TW.resx
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="takeMeBackLinkLabel.Text" xml:space="preserve">
+    <value>&lt;&lt;&lt; 返回</value>
+  </data>
+  <data name="saveImageToFileButton.Text" xml:space="preserve">
+    <value>另存為 PNG</value>
+  </data>
+  <data name="copyToClipboardToolStripMenuItem.Text" xml:space="preserve">
+    <value>複製到剪貼簿</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>快速預覽</value>
+  </data>
+</root>

--- a/src/ParquetViewer/CustomDateFormatInputForm.zh-CN.resx
+++ b/src/ParquetViewer/CustomDateFormatInputForm.zh-CN.resx
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="livePreviewTextBox.PlaceholderText" xml:space="preserve">
+    <value>👈🏽 开始输入以预览</value>
+  </data>
+  <data name="label56.Text" xml:space="preserve">
+    <value>实时预览：</value>
+  </data>
+  <data name="label33.Text" xml:space="preserve">
+    <value>年，四位数字。</value>
+  </data>
+  <data name="label27.Text" xml:space="preserve">
+    <value>年，从 00 到 99。</value>
+  </data>
+  <data name="label21.Text" xml:space="preserve">
+    <value>月，从 01 到 12</value>
+  </data>
+  <data name="label15.Text" xml:space="preserve">
+    <value>月，从 1 到 12。</value>
+  </data>
+  <data name="label9.Text" xml:space="preserve">
+    <value>日，从 01 到 31。</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>日，从 1 到 31。</value>
+  </data>
+  <data name="label38.Text" xml:space="preserve">
+    <value>格式字符串</value>
+  </data>
+  <data name="label39.Text" xml:space="preserve">
+    <value>说明</value>
+  </data>
+  <data name="label40.Text" xml:space="preserve">
+    <value>示例</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>秒，从 0 到 59。</value>
+  </data>
+  <data name="label12.Text" xml:space="preserve">
+    <value>秒，从 00 到 59。</value>
+  </data>
+  <data name="label18.Text" xml:space="preserve">
+    <value>分，从 0 到 59。</value>
+  </data>
+  <data name="label24.Text" xml:space="preserve">
+    <value>分，从 00 到 59。</value>
+  </data>
+  <data name="label30.Text" xml:space="preserve">
+    <value>时，12 小时制，从 01 到 12。</value>
+  </data>
+  <data name="label36.Text" xml:space="preserve">
+    <value>时，24 小时制，从 00 到 23。</value>
+  </data>
+  <data name="label48.Text" xml:space="preserve">
+    <value>日期中的毫秒部分。</value>
+  </data>
+  <data name="label54.Text" xml:space="preserve">
+    <value>时间值中秒的十分之一微秒。</value>
+  </data>
+  <data name="label45.Text" xml:space="preserve">
+    <value>AM/PM 指示符。</value>
+  </data>
+  <data name="dateFormatDocsLinkLabel.Text" xml:space="preserve">
+    <value>点击此处查看所有格式字符串</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>请输入您想要的日期格式：</value>
+  </data>
+  <data name="desiredDateFormatTextBox.PlaceholderText" xml:space="preserve">
+    <value>例如：yyyy-MM-dd hh:mm:ss tt</value>
+  </data>
+  <data name="saveDateFormatButton.Text" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>ParquetViewer - 日期格式设置</value>
+  </data>
+</root>

--- a/src/ParquetViewer/CustomDateFormatInputForm.zh-TW.resx
+++ b/src/ParquetViewer/CustomDateFormatInputForm.zh-TW.resx
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="livePreviewTextBox.PlaceholderText" xml:space="preserve">
+    <value>👈🏽 開始輸入以預覽</value>
+  </data>
+  <data name="label56.Text" xml:space="preserve">
+    <value>即時預覽：</value>
+  </data>
+  <data name="label33.Text" xml:space="preserve">
+    <value>年，四位數。</value>
+  </data>
+  <data name="label27.Text" xml:space="preserve">
+    <value>年，從 00 到 99。</value>
+  </data>
+  <data name="label21.Text" xml:space="preserve">
+    <value>月，從 01 到 12</value>
+  </data>
+  <data name="label15.Text" xml:space="preserve">
+    <value>月，從 1 到 12。</value>
+  </data>
+  <data name="label9.Text" xml:space="preserve">
+    <value>日，從 01 到 31。</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>日，從 1 到 31。</value>
+  </data>
+  <data name="label38.Text" xml:space="preserve">
+    <value>格式字串</value>
+  </data>
+  <data name="label39.Text" xml:space="preserve">
+    <value>說明</value>
+  </data>
+  <data name="label40.Text" xml:space="preserve">
+    <value>範例</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>秒，從 0 到 59。</value>
+  </data>
+  <data name="label12.Text" xml:space="preserve">
+    <value>秒，從 00 到 59。</value>
+  </data>
+  <data name="label18.Text" xml:space="preserve">
+    <value>分，從 0 到 59。</value>
+  </data>
+  <data name="label24.Text" xml:space="preserve">
+    <value>分，從 00 到 59。</value>
+  </data>
+  <data name="label30.Text" xml:space="preserve">
+    <value>時，12 小時制，從 01 到 12。</value>
+  </data>
+  <data name="label36.Text" xml:space="preserve">
+    <value>時，24 小時制，從 00 到 23。</value>
+  </data>
+  <data name="label48.Text" xml:space="preserve">
+    <value>日期中的毫秒部分。</value>
+  </data>
+  <data name="label54.Text" xml:space="preserve">
+    <value>時間值中秒的十分之一微秒。</value>
+  </data>
+  <data name="label45.Text" xml:space="preserve">
+    <value>AM/PM 指示項。</value>
+  </data>
+  <data name="dateFormatDocsLinkLabel.Text" xml:space="preserve">
+    <value>按一下此處查看所有格式字串</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>請輸入您想要的日期格式：</value>
+  </data>
+  <data name="desiredDateFormatTextBox.PlaceholderText" xml:space="preserve">
+    <value>例如：yyyy-MM-dd hh:mm:ss tt</value>
+  </data>
+  <data name="saveDateFormatButton.Text" xml:space="preserve">
+    <value>儲存</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>ParquetViewer - 日期格式設定</value>
+  </data>
+</root>

--- a/src/ParquetViewer/FieldSelectionDialog.zh-CN.resx
+++ b/src/ParquetViewer/FieldSelectionDialog.zh-CN.resx
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="doneButton.Text" xml:space="preserve">
+    <value>完成</value>
+  </data>
+  <data name="showSelectedFieldsRadioButton.Text" xml:space="preserve">
+    <value>已选字段（数量：{0}）：</value>
+  </data>
+  <data name="allFieldsRadioButton.Text" xml:space="preserve">
+    <value>所有字段</value>
+  </data>
+  <data name="rememberMyChoiceCheckBox.Text" xml:space="preserve">
+    <value>记住我的选择</value>
+  </data>
+  <data name="filterColumnsTextbox.PlaceholderText" xml:space="preserve">
+    <value>按字段名称筛选</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>选择要加载的字段</value>
+  </data>
+</root>

--- a/src/ParquetViewer/FieldSelectionDialog.zh-TW.resx
+++ b/src/ParquetViewer/FieldSelectionDialog.zh-TW.resx
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="doneButton.Text" xml:space="preserve">
+    <value>完成</value>
+  </data>
+  <data name="showSelectedFieldsRadioButton.Text" xml:space="preserve">
+    <value>已選欄位（數量：{0}）：</value>
+  </data>
+  <data name="allFieldsRadioButton.Text" xml:space="preserve">
+    <value>所有欄位</value>
+  </data>
+  <data name="rememberMyChoiceCheckBox.Text" xml:space="preserve">
+    <value>記住我的選擇</value>
+  </data>
+  <data name="filterColumnsTextbox.PlaceholderText" xml:space="preserve">
+    <value>依欄位名稱篩選</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>選擇要載入的欄位</value>
+  </data>
+</root>

--- a/src/ParquetViewer/MainForm.Designer.cs
+++ b/src/ParquetViewer/MainForm.Designer.cs
@@ -363,7 +363,7 @@ namespace ParquetViewer
             // 
             // languageToolStripMenuItem
             // 
-            languageToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { englishToolStripMenuItem, turkishToolStripMenuItem });
+            languageToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { englishToolStripMenuItem, simplifiedChineseToolStripMenuItem, traditionalChineseToolStripMenuItem, turkishToolStripMenuItem });
             languageToolStripMenuItem.Image = Resources.Icons.localization_icon;
             languageToolStripMenuItem.Name = "languageToolStripMenuItem";
             resources.ApplyResources(languageToolStripMenuItem, "languageToolStripMenuItem");
@@ -381,6 +381,20 @@ namespace ParquetViewer
             resources.ApplyResources(turkishToolStripMenuItem, "turkishToolStripMenuItem");
             turkishToolStripMenuItem.Tag = "tr-TR";
             turkishToolStripMenuItem.Click += languageToolStripMenuItem_Click;
+            // 
+            // simplifiedChineseToolStripMenuItem
+            // 
+            simplifiedChineseToolStripMenuItem.Name = "simplifiedChineseToolStripMenuItem";
+            resources.ApplyResources(simplifiedChineseToolStripMenuItem, "simplifiedChineseToolStripMenuItem");
+            simplifiedChineseToolStripMenuItem.Tag = "zh-CN";
+            simplifiedChineseToolStripMenuItem.Click += languageToolStripMenuItem_Click;
+            // 
+            // traditionalChineseToolStripMenuItem
+            // 
+            traditionalChineseToolStripMenuItem.Name = "traditionalChineseToolStripMenuItem";
+            resources.ApplyResources(traditionalChineseToolStripMenuItem, "traditionalChineseToolStripMenuItem");
+            traditionalChineseToolStripMenuItem.Tag = "zh-TW";
+            traditionalChineseToolStripMenuItem.Click += languageToolStripMenuItem_Click;
             // 
             // aboutToolStripMenuItem
             // 
@@ -529,6 +543,8 @@ namespace ParquetViewer
         private ToolStripMenuItem languageToolStripMenuItem;
         private ToolStripMenuItem englishToolStripMenuItem;
         private ToolStripMenuItem turkishToolStripMenuItem;
+        private ToolStripMenuItem simplifiedChineseToolStripMenuItem;
+        private ToolStripMenuItem traditionalChineseToolStripMenuItem;
     }
 }
 

--- a/src/ParquetViewer/MainForm.resx
+++ b/src/ParquetViewer/MainForm.resx
@@ -831,6 +831,18 @@
   <data name="turkishToolStripMenuItem.Text" xml:space="preserve">
     <value>Türkçe</value>
   </data>
+  <data name="simplifiedChineseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 22</value>
+  </data>
+  <data name="simplifiedChineseToolStripMenuItem.Text" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="traditionalChineseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 22</value>
+  </data>
+  <data name="traditionalChineseToolStripMenuItem.Text" xml:space="preserve">
+    <value>繁體中文</value>
+  </data>
   <data name="languageToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>165, 22</value>
   </data>

--- a/src/ParquetViewer/MainForm.tr.resx
+++ b/src/ParquetViewer/MainForm.tr.resx
@@ -441,6 +441,18 @@
   <data name="shareAnonymousUsageDataToolStripMenuItem.ToolTipText" xml:space="preserve">
     <value>Gizlilik politikası için Hakkında sayfasına bakınız</value>
   </data>
+  <data name="simplifiedChineseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
+  </data>
+  <data name="simplifiedChineseToolStripMenuItem.Text" xml:space="preserve">
+    <value>Basitleştirilmiş Çince</value>
+  </data>
+  <data name="traditionalChineseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
+  </data>
+  <data name="traditionalChineseToolStripMenuItem.Text" xml:space="preserve">
+    <value>Geleneksel Çince</value>
+  </data>
   <data name="languageToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>187, 22</value>
   </data>

--- a/src/ParquetViewer/MainForm.zh-CN.resx
+++ b/src/ParquetViewer/MainForm.zh-CN.resx
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="recordsToLabel.Text" xml:space="preserve">
+    <value>记录数：</value>
+  </data>
+  <data name="recordsToLabel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="recordCountTextBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="showRecordsFromLabel.Text" xml:space="preserve">
+    <value>跳过记录：</value>
+  </data>
+  <data name="showRecordsFromLabel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="offsetTextBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="runQueryButton.Text" xml:space="preserve">
+    <value>运行</value>
+  </data>
+  <data name="runQueryButton.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="searchFilterLabel.Text" xml:space="preserve">
+    <value>筛选查询（？）：</value>
+  </data>
+  <data name="searchFilterLabel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="searchFilterTextBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="clearFilterButton.Text" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="clearFilterButton.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="mainGridView.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="loadAllRowsButton.ToolTip" xml:space="preserve">
+    <value>加载所有记录（Ctrl+E）</value>
+  </data>
+  <data name="mainTableLayoutPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="mainMenuStrip.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="fileToolStripMenuItem.Text" xml:space="preserve">
+    <value>文件</value>
+  </data>
+  <data name="newToolStripMenuItem.Text" xml:space="preserve">
+    <value>新建</value>
+  </data>
+  <data name="openToolStripMenuItem.Text" xml:space="preserve">
+    <value>打开文件</value>
+  </data>
+  <data name="openFolderToolStripMenuItem.Text" xml:space="preserve">
+    <value>打开文件夹</value>
+  </data>
+  <data name="openFolderToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>文件夹中所有 parquet 文件必须具有相同的架构</value>
+  </data>
+  <data name="saveAsToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出结果</value>
+  </data>
+  <data name="exitToolStripMenuItem.Text" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="editToolStripMenuItem.Text" xml:space="preserve">
+    <value>编辑</value>
+  </data>
+  <data name="changeFieldsMenuStripButton.Text" xml:space="preserve">
+    <value>添加/删除字段</value>
+  </data>
+  <data name="changeDateFormatToolStripMenuItem.Text" xml:space="preserve">
+    <value>日期格式</value>
+  </data>
+  <data name="defaultToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>本地日期格式</value>
+  </data>
+  <data name="customDateFormatToolStripMenuItem.Text" xml:space="preserve">
+    <value>自定义...</value>
+  </data>
+  <data name="alwaysLoadAllRecordsToolStripMenuItem.Text" xml:space="preserve">
+    <value>始终加载所有记录</value>
+  </data>
+  <data name="alwaysLoadAllRecordsToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>打开新文件时，ParquetViewer 将加载文件中的所有记录</value>
+  </data>
+  <data name="darkModeToolStripMenuItem.Text" xml:space="preserve">
+    <value>深色模式</value>
+  </data>
+  <data name="toolsToolStripMenuItem.Text" xml:space="preserve">
+    <value>工具</value>
+  </data>
+  <data name="getSQLCreateTableScriptToolStripMenuItem.Text" xml:space="preserve">
+    <value>生成 SQL 建表脚本</value>
+  </data>
+  <data name="getSQLCreateTableScriptToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>表架构将包含已加载的字段</value>
+  </data>
+  <data name="metadataViewerToolStripMenuItem.Text" xml:space="preserve">
+    <value>元数据查看器</value>
+  </data>
+  <data name="openQueryEditorToolToolStripMenuItem.Text" xml:space="preserve">
+    <value>查询编辑器（Beta）</value>
+  </data>
+  <data name="helpToolStripMenuItem.Text" xml:space="preserve">
+    <value>帮助</value>
+  </data>
+  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve">
+    <value>用户指南</value>
+  </data>
+  <data name="shareAnonymousUsageDataToolStripMenuItem.Text" xml:space="preserve">
+    <value>分享使用数据</value>
+  </data>
+  <data name="shareAnonymousUsageDataToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>隐私政策请参见关于页面</value>
+  </data>
+  <data name="languageToolStripMenuItem.Text" xml:space="preserve">
+    <value>语言</value>
+  </data>
+  <data name="simplifiedChineseToolStripMenuItem.Text" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="traditionalChineseToolStripMenuItem.Text" xml:space="preserve">
+    <value>繁體中文</value>
+  </data>
+  <data name="aboutToolStripMenuItem.Text" xml:space="preserve">
+    <value>关于...</value>
+  </data>
+  <data name="showingRecordCountStatusBarLabel.Text" xml:space="preserve">
+    <value>显示：</value>
+  </data>
+  <data name="recordsTextStatusBarLabel.Text" xml:space="preserve">
+    <value>结果</value>
+  </data>
+  <data name="showingStatusBarLabel.Text" xml:space="preserve">
+    <value>已加载：</value>
+  </data>
+  <data name="outOfStatusBarLabel.Text" xml:space="preserve">
+    <value>总计：</value>
+  </data>
+  <data name="mainStatusStrip.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>新建 Parquet 文件</value>
+  </data>
+  <data name="$this.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+</root>

--- a/src/ParquetViewer/MainForm.zh-TW.resx
+++ b/src/ParquetViewer/MainForm.zh-TW.resx
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="recordsToLabel.Text" xml:space="preserve">
+    <value>記錄數：</value>
+  </data>
+  <data name="recordsToLabel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="recordCountTextBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="showRecordsFromLabel.Text" xml:space="preserve">
+    <value>跳過記錄：</value>
+  </data>
+  <data name="showRecordsFromLabel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="offsetTextBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="runQueryButton.Text" xml:space="preserve">
+    <value>執行</value>
+  </data>
+  <data name="runQueryButton.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="searchFilterLabel.Text" xml:space="preserve">
+    <value>篩選查詢（？）：</value>
+  </data>
+  <data name="searchFilterLabel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="searchFilterTextBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="clearFilterButton.Text" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="clearFilterButton.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="mainGridView.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="loadAllRowsButton.ToolTip" xml:space="preserve">
+    <value>載入所有記錄（Ctrl+E）</value>
+  </data>
+  <data name="mainTableLayoutPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="mainMenuStrip.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="fileToolStripMenuItem.Text" xml:space="preserve">
+    <value>檔案</value>
+  </data>
+  <data name="newToolStripMenuItem.Text" xml:space="preserve">
+    <value>新增</value>
+  </data>
+  <data name="openToolStripMenuItem.Text" xml:space="preserve">
+    <value>開啟檔案</value>
+  </data>
+  <data name="openFolderToolStripMenuItem.Text" xml:space="preserve">
+    <value>開啟資料夾</value>
+  </data>
+  <data name="openFolderToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>資料夾中所有 parquet 檔案必須具有相同的結構描述</value>
+  </data>
+  <data name="saveAsToolStripMenuItem.Text" xml:space="preserve">
+    <value>匯出結果</value>
+  </data>
+  <data name="exitToolStripMenuItem.Text" xml:space="preserve">
+    <value>結束</value>
+  </data>
+  <data name="editToolStripMenuItem.Text" xml:space="preserve">
+    <value>編輯</value>
+  </data>
+  <data name="changeFieldsMenuStripButton.Text" xml:space="preserve">
+    <value>新增/移除欄位</value>
+  </data>
+  <data name="changeDateFormatToolStripMenuItem.Text" xml:space="preserve">
+    <value>日期格式</value>
+  </data>
+  <data name="defaultToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>本地日期格式</value>
+  </data>
+  <data name="customDateFormatToolStripMenuItem.Text" xml:space="preserve">
+    <value>自訂...</value>
+  </data>
+  <data name="alwaysLoadAllRecordsToolStripMenuItem.Text" xml:space="preserve">
+    <value>一律載入所有記錄</value>
+  </data>
+  <data name="alwaysLoadAllRecordsToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>開啟新檔案時，ParquetViewer 將載入檔案中的所有記錄</value>
+  </data>
+  <data name="darkModeToolStripMenuItem.Text" xml:space="preserve">
+    <value>深色模式</value>
+  </data>
+  <data name="toolsToolStripMenuItem.Text" xml:space="preserve">
+    <value>工具</value>
+  </data>
+  <data name="getSQLCreateTableScriptToolStripMenuItem.Text" xml:space="preserve">
+    <value>產生 SQL 建立資料表指令碼</value>
+  </data>
+  <data name="getSQLCreateTableScriptToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>資料表結構描述將包含已載入的欄位</value>
+  </data>
+  <data name="metadataViewerToolStripMenuItem.Text" xml:space="preserve">
+    <value>中繼資料檢視器</value>
+  </data>
+  <data name="openQueryEditorToolToolStripMenuItem.Text" xml:space="preserve">
+    <value>查詢編輯器（Beta）</value>
+  </data>
+  <data name="helpToolStripMenuItem.Text" xml:space="preserve">
+    <value>說明</value>
+  </data>
+  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve">
+    <value>使用者指南</value>
+  </data>
+  <data name="shareAnonymousUsageDataToolStripMenuItem.Text" xml:space="preserve">
+    <value>分享使用資料</value>
+  </data>
+  <data name="shareAnonymousUsageDataToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>隱私權政策請參閱關於頁面</value>
+  </data>
+  <data name="languageToolStripMenuItem.Text" xml:space="preserve">
+    <value>語言</value>
+  </data>
+  <data name="simplifiedChineseToolStripMenuItem.Text" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="traditionalChineseToolStripMenuItem.Text" xml:space="preserve">
+    <value>繁體中文</value>
+  </data>
+  <data name="aboutToolStripMenuItem.Text" xml:space="preserve">
+    <value>關於...</value>
+  </data>
+  <data name="showingRecordCountStatusBarLabel.Text" xml:space="preserve">
+    <value>顯示：</value>
+  </data>
+  <data name="recordsTextStatusBarLabel.Text" xml:space="preserve">
+    <value>結果</value>
+  </data>
+  <data name="showingStatusBarLabel.Text" xml:space="preserve">
+    <value>已載入：</value>
+  </data>
+  <data name="outOfStatusBarLabel.Text" xml:space="preserve">
+    <value>總計：</value>
+  </data>
+  <data name="mainStatusStrip.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>新增 Parquet 檔案</value>
+  </data>
+  <data name="$this.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+</root>

--- a/src/ParquetViewer/MetadataViewer.zh-CN.resx
+++ b/src/ParquetViewer/MetadataViewer.zh-CN.resx
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="loadingTab.Text" xml:space="preserve">
+    <value>正在加载...</value>
+  </data>
+  <data name="closeButton.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="copyRawThriftMetadataButton.Text" xml:space="preserve">
+    <value>复制原始元数据</value>
+  </data>
+  <data name="copyRawThriftMetadataButton.ToolTip" xml:space="preserve">
+    <value>将原始 Thrift 元数据复制到剪贴板</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Parquet 元数据查看器</value>
+  </data>
+</root>

--- a/src/ParquetViewer/MetadataViewer.zh-TW.resx
+++ b/src/ParquetViewer/MetadataViewer.zh-TW.resx
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="loadingTab.Text" xml:space="preserve">
+    <value>正在載入...</value>
+  </data>
+  <data name="closeButton.Text" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="copyRawThriftMetadataButton.Text" xml:space="preserve">
+    <value>複製原始中繼資料</value>
+  </data>
+  <data name="copyRawThriftMetadataButton.ToolTip" xml:space="preserve">
+    <value>將原始 Thrift 中繼資料複製到剪貼簿</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Parquet 中繼資料檢視器</value>
+  </data>
+</root>

--- a/src/ParquetViewer/Resources/Errors.zh-CN.resx
+++ b/src/ParquetViewer/Resources/Errors.zh-CN.resx
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CopyRawMetadataFailedErrorMessage" xml:space="preserve">
+    <value>复制元数据到剪贴板时出错。是否要将数据保存到文件？</value>
+  </data>
+  <data name="CopyRawMetadataFailedErrorTitle" xml:space="preserve">
+    <value>复制错误</value>
+  </data>
+  <data name="FieldListGenerationError" xml:space="preserve">
+    <value>生成字段列表时出错。</value>
+  </data>
+  <data name="FileAssociationFailedErrorMessageFormat" xml:space="preserve">
+    <value>出现问题（错误代码：{0}）。请以管理员身份运行 ParquetViewer 后重试。</value>
+  </data>
+  <data name="FileAssociationFailedErrorTitle" xml:space="preserve">
+    <value>文件关联失败</value>
+  </data>
+  <data name="GenericErrorMessage" xml:space="preserve">
+    <value>出现问题</value>
+  </data>
+  <data name="InvalidDateFormatErrorMessage" xml:space="preserve">
+    <value>无效的日期格式。请查阅文档了解有效的格式字符串。</value>
+  </data>
+  <data name="InvalidDateFormatErrorTitle" xml:space="preserve">
+    <value>无效的日期格式</value>
+  </data>
+  <data name="InvalidQueryErrorTitle" xml:space="preserve">
+    <value>无效的查询</value>
+  </data>
+  <data name="MetadataReadErrorMessage" xml:space="preserve">
+    <value>读取文件元数据时出错。</value>
+  </data>
+  <data name="MetadataReadErrorTitle" xml:space="preserve">
+    <value>元数据错误</value>
+  </data>
+  <data name="NestedListOfTypeNotSupportedMessageFormat" xml:space="preserve">
+    <value>包含 {1} 的 {0} 字段目前不受支持</value>
+  </data>
+  <data name="NoFieldsFoundErrorMessage" xml:space="preserve">
+    <value>所选文件/文件夹不包含任何字段。</value>
+  </data>
+  <data name="NoFieldsFoundErrorTitle" xml:space="preserve">
+    <value>未找到字段</value>
+  </data>
+  <data name="NoThriftMetadataAvailableErrorMessage" xml:space="preserve">
+    <value>未找到 Thrift 元数据</value>
+  </data>
+  <data name="OpenFileNoLongerExistsErrorMessageFormat" xml:space="preserve">
+    <value>指定的文件/文件夹已不存在：{0}请打开其他文件或文件夹。</value>
+  </data>
+  <data name="ParquetSchemaReadErrorMessage" xml:space="preserve">
+    <value>无法读取 Parquet 架构。</value>
+  </data>
+  <data name="SelectAtLeastOneFieldErrorMessage" xml:space="preserve">
+    <value>请至少选择一个字段</value>
+  </data>
+  <data name="SelectAtLeastOneFieldErrorTitle" xml:space="preserve">
+    <value>错误</value>
+  </data>
+  <data name="StructWithUnsupportedFieldErrorMessageFormat" xml:space="preserve">
+    <value>结构体 `{0}` 包含不支持的字段：`{1}`</value>
+  </data>
+  <data name="TooManyColumnsXlsErrorMessageFormat" xml:space="preserve">
+    <value>.xls 文件格式最多支持 {0} 列。
+
+请选择其他文件类型或减少要保存的字段数量。您的字段数：{1}</value>
+  </data>
+  <data name="TooManyColumnsErrorTitle" xml:space="preserve">
+    <value>列数过多</value>
+  </data>
+  <data name="TooManyColumnsXlsxErrorMessageFormat" xml:space="preserve">
+    <value>.xlsx 文件格式最多支持 {0} 列。
+
+请选择其他文件类型或减少要保存的字段数量。您的字段数：{1}</value>
+  </data>
+  <data name="UnknownFieldTypeErrorMessage" xml:space="preserve">
+    <value>未知的字段类型</value>
+  </data>
+  <data name="UnsupportedExportTypeFormat" xml:space="preserve">
+    <value>不支持的文件类型：'{0}'</value>
+  </data>
+  <data name="ExportFailedErrorTitle" xml:space="preserve">
+    <value>导出到文件失败</value>
+  </data>
+  <data name="NoValidParquetFilesFoundErrorMessage" xml:space="preserve">
+    <value>未找到有效的 parquet 文件。找到的无效文件：</value>
+  </data>
+  <data name="SomeInvalidParquetFilesFoundErrorMessage" xml:space="preserve">
+    <value>某些 parquet 文件无法加载。找到的无效文件：</value>
+  </data>
+  <data name="UnexpectedFileReadErrorMessageFormat" xml:space="preserve">
+    <value>无法读取 Parquet 文件。
+
+如果问题仍然存在，请考虑在项目的 GitHub 仓库中报告：帮助 → 关于
+
+{0}</value>
+  </data>
+  <data name="MultipleSchemasDetectedErrorMessage" xml:space="preserve">
+    <value>检测到多个架构。</value>
+  </data>
+  <data name="MalformedFieldErrorMessageFormat" xml:space="preserve">
+    <value>{0}
+
+如果您认为文件实际上是有效的，请在项目的 GitHub 仓库中报告问题：帮助 → 关于</value>
+  </data>
+  <data name="DecimalValueTooLargeErrorTitle" xml:space="preserve">
+    <value>Decimal 值过大</value>
+  </data>
+  <data name="DecimalValueTooLargeErrorMessageFormat" xml:space="preserve">
+    <value>类型为 DECIMAL({1}, {2}) 的字段 `{0}` 超出了 ParquetViewer 支持的范围：DECIMAL({3}, {4}) 到 DECIMAL({3}, 0)</value>
+  </data>
+  <data name="MultipleSchemasDetectedEntriesErrorMessageFormat" xml:space="preserve">
+    <value>架构-{0} 字段（前 5 个）：</value>
+  </data>
+  <data name="CopyAsWhereTooLargeErrorMessage" xml:space="preserve">
+    <value>选中的数据过多。请选择较少的单元格。</value>
+  </data>
+  <data name="CopyAsWhereTooLargeErrorTitle" xml:space="preserve">
+    <value>复制到剪贴板失败</value>
+  </data>
+  <data name="InvalidQueryErrorMessage" xml:space="preserve">
+    <value>查询似乎无效。</value>
+  </data>
+  <data name="UnexpectedAssemblyVersionErrorFormat" xml:space="preserve">
+    <value>遇到意外的程序版本：{0}</value>
+  </data>
+  <data name="CopyToClipboardErrorTitle" xml:space="preserve">
+    <value>复制到剪贴板失败</value>
+  </data>
+  <data name="CopyErrorMessageText" xml:space="preserve">
+    <value>（按 CTRL+C 复制）</value>
+  </data>
+  <data name="DecimalValueUnknownSizeTooLargeErrorMessageFormat" xml:space="preserve">
+    <value>遇到超出 ParquetViewer 支持范围（DECIMAL({3}, {4}) 到 DECIMAL({3}, 0)）的 DECIMAL 值</value>
+  </data>
+  <data name="ListsWithNullsErrorMessage" xml:space="preserve">
+    <value>不支持包含 null 的列表。</value>
+  </data>
+  <data name="ListsWithNullsErrorTitle" xml:space="preserve">
+    <value>无法读取所有记录</value>
+  </data>
+  <data name="QueryExecutionErrorTitle" xml:space="preserve">
+    <value>处理查询时出错</value>
+  </data>
+  <data name="RenderResultsErrorTitle" xml:space="preserve">
+    <value>显示结果时出错</value>
+  </data>
+</root>

--- a/src/ParquetViewer/Resources/Errors.zh-TW.resx
+++ b/src/ParquetViewer/Resources/Errors.zh-TW.resx
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CopyRawMetadataFailedErrorMessage" xml:space="preserve">
+    <value>複製中繼資料到剪貼簿時發生錯誤。是否要將資料儲存到檔案？</value>
+  </data>
+  <data name="CopyRawMetadataFailedErrorTitle" xml:space="preserve">
+    <value>複製錯誤</value>
+  </data>
+  <data name="FieldListGenerationError" xml:space="preserve">
+    <value>產生欄位清單時發生錯誤。</value>
+  </data>
+  <data name="FileAssociationFailedErrorMessageFormat" xml:space="preserve">
+    <value>出現問題（錯誤代碼：{0}）。請以系統管理員身分執行 ParquetViewer 後重試。</value>
+  </data>
+  <data name="FileAssociationFailedErrorTitle" xml:space="preserve">
+    <value>檔案關聯失敗</value>
+  </data>
+  <data name="GenericErrorMessage" xml:space="preserve">
+    <value>出現問題</value>
+  </data>
+  <data name="InvalidDateFormatErrorMessage" xml:space="preserve">
+    <value>無效的日期格式。請查閱文件了解有效的格式字串。</value>
+  </data>
+  <data name="InvalidDateFormatErrorTitle" xml:space="preserve">
+    <value>無效的日期格式</value>
+  </data>
+  <data name="InvalidQueryErrorTitle" xml:space="preserve">
+    <value>無效的查詢</value>
+  </data>
+  <data name="MetadataReadErrorMessage" xml:space="preserve">
+    <value>讀取檔案中繼資料時發生錯誤。</value>
+  </data>
+  <data name="MetadataReadErrorTitle" xml:space="preserve">
+    <value>中繼資料錯誤</value>
+  </data>
+  <data name="NestedListOfTypeNotSupportedMessageFormat" xml:space="preserve">
+    <value>包含 {1} 的 {0} 欄位目前不受支援</value>
+  </data>
+  <data name="NoFieldsFoundErrorMessage" xml:space="preserve">
+    <value>所選檔案/資料夾不包含任何欄位。</value>
+  </data>
+  <data name="NoFieldsFoundErrorTitle" xml:space="preserve">
+    <value>找不到欄位</value>
+  </data>
+  <data name="NoThriftMetadataAvailableErrorMessage" xml:space="preserve">
+    <value>找不到 Thrift 中繼資料</value>
+  </data>
+  <data name="OpenFileNoLongerExistsErrorMessageFormat" xml:space="preserve">
+    <value>指定的檔案/資料夾已不存在：{0}請開啟其他檔案或資料夾。</value>
+  </data>
+  <data name="ParquetSchemaReadErrorMessage" xml:space="preserve">
+    <value>無法讀取 Parquet 結構描述。</value>
+  </data>
+  <data name="SelectAtLeastOneFieldErrorMessage" xml:space="preserve">
+    <value>請至少選取一個欄位</value>
+  </data>
+  <data name="SelectAtLeastOneFieldErrorTitle" xml:space="preserve">
+    <value>錯誤</value>
+  </data>
+  <data name="StructWithUnsupportedFieldErrorMessageFormat" xml:space="preserve">
+    <value>結構 `{0}` 包含不支援的欄位：`{1}`</value>
+  </data>
+  <data name="TooManyColumnsXlsErrorMessageFormat" xml:space="preserve">
+    <value>.xls 檔案格式最多支援 {0} 欄。
+
+請選擇其他檔案類型或減少要儲存的欄位數量。您的欄位數：{1}</value>
+  </data>
+  <data name="TooManyColumnsErrorTitle" xml:space="preserve">
+    <value>欄數過多</value>
+  </data>
+  <data name="TooManyColumnsXlsxErrorMessageFormat" xml:space="preserve">
+    <value>.xlsx 檔案格式最多支援 {0} 欄。
+
+請選擇其他檔案類型或減少要儲存的欄位數量。您的欄位數：{1}</value>
+  </data>
+  <data name="UnknownFieldTypeErrorMessage" xml:space="preserve">
+    <value>未知的欄位類型</value>
+  </data>
+  <data name="UnsupportedExportTypeFormat" xml:space="preserve">
+    <value>不支援的檔案類型：'{0}'</value>
+  </data>
+  <data name="ExportFailedErrorTitle" xml:space="preserve">
+    <value>匯出到檔案失敗</value>
+  </data>
+  <data name="NoValidParquetFilesFoundErrorMessage" xml:space="preserve">
+    <value>找不到有效的 parquet 檔案。找到的無效檔案：</value>
+  </data>
+  <data name="SomeInvalidParquetFilesFoundErrorMessage" xml:space="preserve">
+    <value>某些 parquet 檔案無法載入。找到的無效檔案：</value>
+  </data>
+  <data name="UnexpectedFileReadErrorMessageFormat" xml:space="preserve">
+    <value>無法讀取 Parquet 檔案。
+
+如果問題仍然存在，請考慮在專案的 GitHub 儲存庫中回報：說明 → 關於
+
+{0}</value>
+  </data>
+  <data name="MultipleSchemasDetectedErrorMessage" xml:space="preserve">
+    <value>偵測到多個結構描述。</value>
+  </data>
+  <data name="MalformedFieldErrorMessageFormat" xml:space="preserve">
+    <value>{0}
+
+如果您認為檔案實際上是有效的，請在專案的 GitHub 儲存庫中回報問題：說明 → 關於</value>
+  </data>
+  <data name="DecimalValueTooLargeErrorTitle" xml:space="preserve">
+    <value>Decimal 值過大</value>
+  </data>
+  <data name="DecimalValueTooLargeErrorMessageFormat" xml:space="preserve">
+    <value>類型為 DECIMAL({1}, {2}) 的欄位 `{0}` 超出了 ParquetViewer 支援的範圍：DECIMAL({3}, {4}) 到 DECIMAL({3}, 0)</value>
+  </data>
+  <data name="MultipleSchemasDetectedEntriesErrorMessageFormat" xml:space="preserve">
+    <value>結構描述-{0} 欄位（前 5 個）：</value>
+  </data>
+  <data name="CopyAsWhereTooLargeErrorMessage" xml:space="preserve">
+    <value>選取的資料過多。請選取較少的儲存格。</value>
+  </data>
+  <data name="CopyAsWhereTooLargeErrorTitle" xml:space="preserve">
+    <value>複製到剪貼簿失敗</value>
+  </data>
+  <data name="InvalidQueryErrorMessage" xml:space="preserve">
+    <value>查詢似乎無效。</value>
+  </data>
+  <data name="UnexpectedAssemblyVersionErrorFormat" xml:space="preserve">
+    <value>遇到意外的程式版本：{0}</value>
+  </data>
+  <data name="CopyToClipboardErrorTitle" xml:space="preserve">
+    <value>複製到剪貼簿失敗</value>
+  </data>
+  <data name="CopyErrorMessageText" xml:space="preserve">
+    <value>（按 CTRL+C 複製）</value>
+  </data>
+  <data name="DecimalValueUnknownSizeTooLargeErrorMessageFormat" xml:space="preserve">
+    <value>遇到超出 ParquetViewer 支援範圍（DECIMAL({3}, {4}) 到 DECIMAL({3}, 0)）的 DECIMAL 值</value>
+  </data>
+  <data name="ListsWithNullsErrorMessage" xml:space="preserve">
+    <value>不支援包含 null 的清單。</value>
+  </data>
+  <data name="ListsWithNullsErrorTitle" xml:space="preserve">
+    <value>無法讀取所有記錄</value>
+  </data>
+  <data name="QueryExecutionErrorTitle" xml:space="preserve">
+    <value>處理查詢時發生錯誤</value>
+  </data>
+  <data name="RenderResultsErrorTitle" xml:space="preserve">
+    <value>顯示結果時發生錯誤</value>
+  </data>
+</root>

--- a/src/ParquetViewer/Resources/Strings.zh-CN.resx
+++ b/src/ParquetViewer/Resources/Strings.zh-CN.resx
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LoadedRecordCountRangeFormat" xml:space="preserve">
+    <value>{0} - {1}</value>
+  </data>
+  <data name="LoadingDataLabelText" xml:space="preserve">
+    <value>正在加载数据</value>
+  </data>
+  <data name="CancelInitiatedLabelText" xml:space="preserve">
+    <value>正在取消...</value>
+  </data>
+  <data name="ExportingDataLabelText" xml:space="preserve">
+    <value>正在导出数据</value>
+  </data>
+  <data name="IndexingDataLabelText" xml:space="preserve">
+    <value>正在索引</value>
+  </data>
+  <data name="PrivacyPolicyLabelText" xml:space="preserve">
+    <value>隐私政策</value>
+  </data>
+  <data name="InvalidDateFormatErrorText" xml:space="preserve">
+    <value>无效的日期格式</value>
+  </data>
+  <data name="TooManyFieldsErrorFormat" xml:space="preserve">
+    <value>字段过多：{0}</value>
+  </data>
+  <data name="UnsupportedFieldCountTextFormat" xml:space="preserve">
+    <value>不支持的字段数：{0}</value>
+  </data>
+  <data name="SelectAllCheckmarkTextFormat" xml:space="preserve">
+    <value>全选（数量：{0}）</value>
+  </data>
+  <data name="DeselectAllCheckmarkTextFormat" xml:space="preserve">
+    <value>取消全选（数量：{0}）</value>
+  </data>
+  <data name="ThriftMetadataCopiedToClipboardMessage" xml:space="preserve">
+    <value>原始 Thrift 元数据已复制到剪贴板。</value>
+  </data>
+  <data name="SaveRawMetadataToFileDialogTitle" xml:space="preserve">
+    <value>保存原始元数据</value>
+  </data>
+  <data name="MetadataSuccessfullyExportedToFileMessageFormat" xml:space="preserve">
+    <value>元数据已成功导出到：{0}</value>
+  </data>
+  <data name="MetadataSuccessfullyExportedToFileMessageTitle" xml:space="preserve">
+    <value>导出完成</value>
+  </data>
+  <data name="MainWindowOpenFileTitleFormat" xml:space="preserve">
+    <value>文件：{0}</value>
+  </data>
+  <data name="MainWindowOpenFolderTitleFormat" xml:space="preserve">
+    <value>文件夹：{0}</value>
+  </data>
+  <data name="QuerySyntaxHelpText" xml:space="preserve">
+    <value>空值判断：
+    WHERE field_name IS NULL
+    WHERE field_name IS NOT NULL
+日期时间：
+    WHERE field_name &gt;= #2000-12-31#
+    WHERE field_name = #2000-01-13 01:00:00#
+数值：
+    WHERE field_name &lt;= 123.4
+    WHERE (field1 * field2) / 100 &gt; 0.1
+文本：
+    WHERE field_name LIKE '%value%'
+    WHERE field_name = 'equals value'
+    WHERE field_name &lt;&gt; 'not equals'
+IN 判断：
+    WHERE field_name IN (value1, value2)
+    WHERE field_name NOT IN (value3, value4)
+多条件：
+    WHERE (field_1 = 0 AND field_2 &lt;&gt; 'value') OR field_3 IS NULL
+
+更多信息请查看：帮助 → 用户指南</value>
+  </data>
+  <data name="QuerySyntaxHelpTitle" xml:space="preserve">
+    <value>筛选查询语法示例</value>
+  </data>
+  <data name="RecordsToBeExportedTitleFormat" xml:space="preserve">
+    <value>将导出 {0} 条记录</value>
+  </data>
+  <data name="ExportCancelledMessage" xml:space="preserve">
+    <value>导出已取消</value>
+  </data>
+  <data name="ExportCancelledTitle" xml:space="preserve">
+    <value>导出已取消</value>
+  </data>
+  <data name="ExportSuccessfulMessageFormat" xml:space="preserve">
+    <value>导出成功！
+
+文件大小：{0} MB</value>
+  </data>
+  <data name="ExportSuccessfulTitle" xml:space="preserve">
+    <value>成功</value>
+  </data>
+  <data name="SwitchFromXlsToXlsxMessageFormat" xml:space="preserve">
+    <value>{1} 格式每个单元格最多支持 {0} 个字符。
+
+是否要改为导出为 {2} 文件？</value>
+  </data>
+  <data name="SwitchFromXlsToXlsxMessageTitle" xml:space="preserve">
+    <value>数据过长 - 切换导出格式？</value>
+  </data>
+  <data name="CreateTableScriptCopiedToClipboardMessage" xml:space="preserve">
+    <value>建表脚本已复制到剪贴板！</value>
+  </data>
+  <data name="CreateTableScriptFailedWithNoFieldsMessage" xml:space="preserve">
+    <value>请先选择一些字段以生成 SQL 脚本</value>
+  </data>
+  <data name="CopyToClipboardText" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="CancelButtonText" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="CopyToClipboardWithHeadersText" xml:space="preserve">
+    <value>带标题复制</value>
+  </data>
+  <data name="CopyAsWhereConditionText" xml:space="preserve">
+    <value>复制为 WHERE 条件</value>
+  </data>
+  <data name="DecimalScientificFormatting" xml:space="preserve">
+    <value>科学计数法</value>
+  </data>
+  <data name="DimensionsText" xml:space="preserve">
+    <value>尺寸</value>
+  </data>
+  <data name="TypeText" xml:space="preserve">
+    <value>类型</value>
+  </data>
+  <data name="SaveImageToFileButtonTextFormat" xml:space="preserve">
+    <value>另存为 {0}</value>
+  </data>
+  <data name="CantGoBackLinkButtonText" xml:space="preserve">
+    <value>无法返回</value>
+  </data>
+  <data name="SaveImageAsButtonText" xml:space="preserve">
+    <value>图像另存为 {0}</value>
+  </data>
+  <data name="ImageSavedToDiskMessage" xml:space="preserve">
+    <value>图像已保存到：{0}</value>
+  </data>
+  <data name="ImageSavedToDiskTitle" xml:space="preserve">
+    <value>保存完成</value>
+  </data>
+  <data name="DecimalFormatting" xml:space="preserve">
+    <value>十进制</value>
+  </data>
+  <data name="LanguageChangeConfirmationTitle" xml:space="preserve">
+    <value>重启 ParquetViewer？</value>
+  </data>
+  <data name="LanguageChangeConfirmationMessage" xml:space="preserve">
+    <value>更改语言需要重启应用程序。是否继续？</value>
+  </data>
+  <data name="DotNetDateFormatHelpUrl" xml:space="preserve">
+    <value>https://docs.microsoft.com/zh-cn/dotnet/standard/base-types/custom-date-and-time-format-strings</value>
+  </data>
+  <data name="AnalyticsConsentPromptMessage" xml:space="preserve">
+    <value>是否愿意分享匿名使用数据以帮助改进 ParquetViewer？
+
+您可以随时从帮助菜单更改此设置。</value>
+  </data>
+  <data name="AnalyticsConsentPromptTitle" xml:space="preserve">
+    <value>分享匿名使用数据？</value>
+  </data>
+  <data name="FileExtensionAssociationPromptMessageFormat" xml:space="preserve">
+    <value>是否将 ParquetViewer 关联到 .parquet 文件？
+
+可执行文件路径：{0}
+
+您也可以从帮助 → 关于页面更改此设置。</value>
+  </data>
+  <data name="FileExtensionAssociationPromptTitle" xml:space="preserve">
+    <value>ParquetViewer 文件关联请求</value>
+  </data>
+  <data name="FileExtensionAssociationCancelledMessage" xml:space="preserve">
+    <value>文件关联已取消。如果您改变主意，可以访问帮助 → 关于页面进行设置。</value>
+  </data>
+  <data name="FileExtensionAssociationCancelledTitle" xml:space="preserve">
+    <value>文件关联已取消</value>
+  </data>
+  <data name="FileExtensionAssociationFailedMessageFormat" xml:space="preserve">
+    <value>出现问题（错误代码：{0}）。
+
+您可以从帮助 → 关于页面重试。</value>
+  </data>
+  <data name="FileExtensionAssociationFailedTitle" xml:space="preserve">
+    <value>文件关联失败</value>
+  </data>
+  <data name="FileExtensionAssociationSucceededMessage" xml:space="preserve">
+    <value>成功！ParquetViewer 现在是 .parquet 文件的默认应用程序。</value>
+  </data>
+  <data name="FileExtensionAssociationSucceededTitle" xml:space="preserve">
+    <value>文件关联成功</value>
+  </data>
+  <data name="DarkModePromptMessage" xml:space="preserve">
+    <value>是否要使用深色模式？
+
+您可以随时从编辑菜单切换此设置。</value>
+  </data>
+  <data name="DarkModePromptTitle" xml:space="preserve">
+    <value>切换到深色模式？</value>
+  </data>
+  <data name="QueryRunningStatusText" xml:space="preserve">
+    <value>运行中：</value>
+  </data>
+  <data name="QueryFinishedStatusText" xml:space="preserve">
+    <value>完成用时：</value>
+  </data>
+  <data name="QueryZoomStatusTextFormat" xml:space="preserve">
+    <value>查询缩放：{0}%</value>
+  </data>
+  <data name="ByteArraysNotSupportedErrorMessage" xml:space="preserve">
+    <value>抱歉，byte[] 类型目前不支持在查询结果中显示。值将显示为 null。</value>
+  </data>
+  <data name="ByteArraysNotSupportedErrorTitle" xml:space="preserve">
+    <value>不支持字节数组</value>
+  </data>
+  <data name="FrozenColumnText" xml:space="preserve">
+    <value>冻结</value>
+  </data>
+</root>

--- a/src/ParquetViewer/Resources/Strings.zh-TW.resx
+++ b/src/ParquetViewer/Resources/Strings.zh-TW.resx
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LoadedRecordCountRangeFormat" xml:space="preserve">
+    <value>{0} - {1}</value>
+  </data>
+  <data name="LoadingDataLabelText" xml:space="preserve">
+    <value>正在載入資料</value>
+  </data>
+  <data name="CancelInitiatedLabelText" xml:space="preserve">
+    <value>正在取消...</value>
+  </data>
+  <data name="ExportingDataLabelText" xml:space="preserve">
+    <value>正在匯出資料</value>
+  </data>
+  <data name="IndexingDataLabelText" xml:space="preserve">
+    <value>正在建立索引</value>
+  </data>
+  <data name="PrivacyPolicyLabelText" xml:space="preserve">
+    <value>隱私權政策</value>
+  </data>
+  <data name="InvalidDateFormatErrorText" xml:space="preserve">
+    <value>無效的日期格式</value>
+  </data>
+  <data name="TooManyFieldsErrorFormat" xml:space="preserve">
+    <value>欄位過多：{0}</value>
+  </data>
+  <data name="UnsupportedFieldCountTextFormat" xml:space="preserve">
+    <value>不支援的欄位數：{0}</value>
+  </data>
+  <data name="SelectAllCheckmarkTextFormat" xml:space="preserve">
+    <value>全選（數量：{0}）</value>
+  </data>
+  <data name="DeselectAllCheckmarkTextFormat" xml:space="preserve">
+    <value>取消全選（數量：{0}）</value>
+  </data>
+  <data name="ThriftMetadataCopiedToClipboardMessage" xml:space="preserve">
+    <value>原始 Thrift 中繼資料已複製到剪貼簿。</value>
+  </data>
+  <data name="SaveRawMetadataToFileDialogTitle" xml:space="preserve">
+    <value>儲存原始中繼資料</value>
+  </data>
+  <data name="MetadataSuccessfullyExportedToFileMessageFormat" xml:space="preserve">
+    <value>中繼資料已成功匯出到：{0}</value>
+  </data>
+  <data name="MetadataSuccessfullyExportedToFileMessageTitle" xml:space="preserve">
+    <value>匯出完成</value>
+  </data>
+  <data name="MainWindowOpenFileTitleFormat" xml:space="preserve">
+    <value>檔案：{0}</value>
+  </data>
+  <data name="MainWindowOpenFolderTitleFormat" xml:space="preserve">
+    <value>資料夾：{0}</value>
+  </data>
+  <data name="QuerySyntaxHelpText" xml:space="preserve">
+    <value>空值判斷：
+    WHERE field_name IS NULL
+    WHERE field_name IS NOT NULL
+日期時間：
+    WHERE field_name &gt;= #2000-12-31#
+    WHERE field_name = #2000-01-13 01:00:00#
+數值：
+    WHERE field_name &lt;= 123.4
+    WHERE (field1 * field2) / 100 &gt; 0.1
+文字：
+    WHERE field_name LIKE '%value%'
+    WHERE field_name = 'equals value'
+    WHERE field_name &lt;&gt; 'not equals'
+IN 判斷：
+    WHERE field_name IN (value1, value2)
+    WHERE field_name NOT IN (value3, value4)
+多重條件：
+    WHERE (field_1 = 0 AND field_2 &lt;&gt; 'value') OR field_3 IS NULL
+
+更多資訊請查看：說明 → 使用者指南</value>
+  </data>
+  <data name="QuerySyntaxHelpTitle" xml:space="preserve">
+    <value>篩選查詢語法範例</value>
+  </data>
+  <data name="RecordsToBeExportedTitleFormat" xml:space="preserve">
+    <value>將匯出 {0} 筆記錄</value>
+  </data>
+  <data name="ExportCancelledMessage" xml:space="preserve">
+    <value>匯出已取消</value>
+  </data>
+  <data name="ExportCancelledTitle" xml:space="preserve">
+    <value>匯出已取消</value>
+  </data>
+  <data name="ExportSuccessfulMessageFormat" xml:space="preserve">
+    <value>匯出成功！
+
+檔案大小：{0} MB</value>
+  </data>
+  <data name="ExportSuccessfulTitle" xml:space="preserve">
+    <value>成功</value>
+  </data>
+  <data name="SwitchFromXlsToXlsxMessageFormat" xml:space="preserve">
+    <value>{1} 格式每個儲存格最多支援 {0} 個字元。
+
+是否要切換為 {2} 檔案？</value>
+  </data>
+  <data name="SwitchFromXlsToXlsxMessageTitle" xml:space="preserve">
+    <value>資料過長 - 切換匯出格式？</value>
+  </data>
+  <data name="CreateTableScriptCopiedToClipboardMessage" xml:space="preserve">
+    <value>建立資料表指令碼已複製到剪貼簿！</value>
+  </data>
+  <data name="CreateTableScriptFailedWithNoFieldsMessage" xml:space="preserve">
+    <value>請先選取一些欄位以產生 SQL 指令碼</value>
+  </data>
+  <data name="CopyToClipboardText" xml:space="preserve">
+    <value>複製</value>
+  </data>
+  <data name="CancelButtonText" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="CopyToClipboardWithHeadersText" xml:space="preserve">
+    <value>含標題複製</value>
+  </data>
+  <data name="CopyAsWhereConditionText" xml:space="preserve">
+    <value>複製為 WHERE 條件</value>
+  </data>
+  <data name="DecimalScientificFormatting" xml:space="preserve">
+    <value>科學記號</value>
+  </data>
+  <data name="DimensionsText" xml:space="preserve">
+    <value>尺寸</value>
+  </data>
+  <data name="TypeText" xml:space="preserve">
+    <value>類型</value>
+  </data>
+  <data name="SaveImageToFileButtonTextFormat" xml:space="preserve">
+    <value>另存為 {0}</value>
+  </data>
+  <data name="CantGoBackLinkButtonText" xml:space="preserve">
+    <value>無法返回</value>
+  </data>
+  <data name="SaveImageAsButtonText" xml:space="preserve">
+    <value>影像另存為 {0}</value>
+  </data>
+  <data name="ImageSavedToDiskMessage" xml:space="preserve">
+    <value>影像已儲存到：{0}</value>
+  </data>
+  <data name="ImageSavedToDiskTitle" xml:space="preserve">
+    <value>儲存完成</value>
+  </data>
+  <data name="DecimalFormatting" xml:space="preserve">
+    <value>十進位</value>
+  </data>
+  <data name="LanguageChangeConfirmationTitle" xml:space="preserve">
+    <value>重新啟動 ParquetViewer？</value>
+  </data>
+  <data name="LanguageChangeConfirmationMessage" xml:space="preserve">
+    <value>變更語言需要重新啟動應用程式。是否繼續？</value>
+  </data>
+  <data name="DotNetDateFormatHelpUrl" xml:space="preserve">
+    <value>https://docs.microsoft.com/zh-tw/dotnet/standard/base-types/custom-date-and-time-format-strings</value>
+  </data>
+  <data name="AnalyticsConsentPromptMessage" xml:space="preserve">
+    <value>是否願意分享匿名使用資料以協助改善 ParquetViewer？
+
+您可以隨時從說明功能表變更此設定。</value>
+  </data>
+  <data name="AnalyticsConsentPromptTitle" xml:space="preserve">
+    <value>分享匿名使用資料？</value>
+  </data>
+  <data name="FileExtensionAssociationPromptMessageFormat" xml:space="preserve">
+    <value>是否將 ParquetViewer 關聯到 .parquet 檔案？
+
+可執行檔路徑：{0}
+
+您也可以從說明 → 關於頁面變更此設定。</value>
+  </data>
+  <data name="FileExtensionAssociationPromptTitle" xml:space="preserve">
+    <value>ParquetViewer 檔案關聯請求</value>
+  </data>
+  <data name="FileExtensionAssociationCancelledMessage" xml:space="preserve">
+    <value>檔案關聯已取消。如果您改變主意，可以前往說明 → 關於頁面進行設定。</value>
+  </data>
+  <data name="FileExtensionAssociationCancelledTitle" xml:space="preserve">
+    <value>檔案關聯已取消</value>
+  </data>
+  <data name="FileExtensionAssociationFailedMessageFormat" xml:space="preserve">
+    <value>出現問題（錯誤代碼：{0}）。
+
+您可以從說明 → 關於頁面重試。</value>
+  </data>
+  <data name="FileExtensionAssociationFailedTitle" xml:space="preserve">
+    <value>檔案關聯失敗</value>
+  </data>
+  <data name="FileExtensionAssociationSucceededMessage" xml:space="preserve">
+    <value>成功！ParquetViewer 現在是 .parquet 檔案的預設應用程式。</value>
+  </data>
+  <data name="FileExtensionAssociationSucceededTitle" xml:space="preserve">
+    <value>檔案關聯成功</value>
+  </data>
+  <data name="DarkModePromptMessage" xml:space="preserve">
+    <value>是否要使用深色模式？
+
+您可以隨時從編輯功能表切換此設定。</value>
+  </data>
+  <data name="DarkModePromptTitle" xml:space="preserve">
+    <value>切換到深色模式？</value>
+  </data>
+  <data name="QueryRunningStatusText" xml:space="preserve">
+    <value>執行中：</value>
+  </data>
+  <data name="QueryFinishedStatusText" xml:space="preserve">
+    <value>完成用時：</value>
+  </data>
+  <data name="QueryZoomStatusTextFormat" xml:space="preserve">
+    <value>查詢縮放：{0}%</value>
+  </data>
+  <data name="ByteArraysNotSupportedErrorMessage" xml:space="preserve">
+    <value>抱歉，byte[] 類型目前不支援在查詢結果中顯示。值將顯示為 null。</value>
+  </data>
+  <data name="ByteArraysNotSupportedErrorTitle" xml:space="preserve">
+    <value>不支援位元組陣列</value>
+  </data>
+  <data name="FrozenColumnText" xml:space="preserve">
+    <value>凍結</value>
+  </data>
+</root>


### PR DESCRIPTION
…zation

- Add zh-CN and zh-TW menu items under Help > Language in MainForm
- Create zh-CN and zh-TW satellite .resx files for all 8 translatable resource groups matching the existing Turkish (.tr.resx) pattern: Strings, Errors, MainForm, AboutBox, FieldSelectionDialog, MetadataViewer, CustomDateFormatInputForm, QuickPeekForm
- Update MainForm.tr.resx with Turkish text for new Chinese menu items