### PR TITLE
Format filter query values with invariant culture

### DIFF
--- a/src/ParquetViewer.Tests/HelperTests.cs
+++ b/src/ParquetViewer.Tests/HelperTests.cs
@@ -286,6 +286,46 @@ namespace ParquetViewer.Tests
         }
 
         [TestMethod]
+        [DataRow("de-DE")] //comma decimal separator
+        [DataRow("fr-FR")] //comma decimal separator + narrow no-break group separator
+        [DataRow("th-TH")] //non-Gregorian calendar by default
+        public void NumericAndDateFilters_AreCultureInvariant(string cultureName)
+        {
+            //DataView.RowFilter always expects '.' as the decimal separator and a Gregorian date,
+            //regardless of the user's locale. Without invariant formatting, a culture that uses ','
+            //would corrupt the filter since ',' also separates values inside an `IN (...)` clause.
+            var originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+
+                Assert.AreEqual("Value = 1.5", ParquetGridView.GenerateFilterQuery(new()
+                {
+                    ("Value", typeof(double), new object[] { 1.5d })
+                }));
+
+                Assert.AreEqual("Value = '1.23E+20'", ParquetGridView.GenerateFilterQuery(new()
+                {
+                    ("Value", typeof(double), new object[] { 1.23e20 })
+                }));
+
+                Assert.AreEqual("Value IN (1.5,2.5)", ParquetGridView.GenerateFilterQuery(new()
+                {
+                    ("Value", typeof(double), new object[] { 1.5d, 2.5d })
+                }));
+
+                Assert.AreEqual("Value = #2024-01-31 13:45:30#", ParquetGridView.GenerateFilterQuery(new()
+                {
+                    ("Value", typeof(DateTime), new object[] { new DateTime(2024, 1, 31, 13, 45, 30) })
+                }));
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        [TestMethod]
         public void ByteArrayValue_IsCorrectlyTruncated()
         {
             var byteArrayValue = new Engine.Types.ByteArrayValue([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10]);

--- a/src/ParquetViewer/Controls/ParquetGridView.cs
+++ b/src/ParquetViewer/Controls/ParquetGridView.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -1050,12 +1051,18 @@ namespace ParquetViewer.Controls
                     {
                         if (valueType == typeof(DateTime))
                         {
-                            //Use a standard date format so the query is always syntactically correct
-                            queryBuilder.AppendFormat(dateValueEscapeFormat, ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss.FFFFFFF"));
+                            //Use a standard date format so the query is always syntactically correct.
+                            //Invariant culture is required: custom format strings still resolve the calendar from
+                            //the current culture, so locales like th-TH would emit a non-Gregorian year.
+                            queryBuilder.AppendFormat(CultureInfo.InvariantCulture, dateValueEscapeFormat,
+                                ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss.FFFFFFF", CultureInfo.InvariantCulture));
                         }
                         else if (valueType.IsNumber())
                         {
-                            var stringValue = value.ToString();
+                            //DataView.RowFilter syntax is culture invariant: it always expects '.' as the decimal
+                            //separator. Formatting with the current culture would emit ',' in locales like de-DE,
+                            //which silently corrupts the filter since ',' separates values inside an `IN (...)` clause.
+                            var stringValue = Convert.ToString(value, CultureInfo.InvariantCulture);
                             if ((valueType == typeof(float) || valueType == typeof(double))
                                 && stringValue?.Contains('E', StringComparison.OrdinalIgnoreCase) == true)
                                 stringValue = $"'{stringValue}'"; //scientific notation values need to be wrapped in single quotes


### PR DESCRIPTION
`GenerateFilterQuery` builds a `DataView.RowFilter` expression, and that syntax is culture invariant:
it always expects `.` as the decimal separator and a Gregorian calendar.

Both the numeric and `DateTime` paths were formatting with the current culture instead.

On a locale that uses a comma as the decimal separator, a float rendered as `1,5`. 
Inside an `IN (...)` clause the comma also separates values, so the filter silently matched the wrong rows rather than failing outright. 

On a locale with a non-Gregorian default calendar, such as `th-TH`, the `DateTime` path emitted year 2567 for 2024. 
A custom format string does not avoid this: it still resolves the calendar from the current culture.

This is already visible in the existing suite. 

`FloatScientificNotation_IsWrappedInQuotes` fails on any comma-decimal machine, expecting `1.23E+20` and getting `1,23E+20`. It passes in CI only because the runner is `en-US`. 

The added test pins the culture explicitly so the regression is caught wherever the suite runs.

Verified locally: `dotnet test` goes from 1 failure to 0 on an `es-ES` machine.